### PR TITLE
Set up directory structure, some code, a test

### DIFF
--- a/src/cilantro/.gitignore
+++ b/src/cilantro/.gitignore
@@ -1,0 +1,32 @@
+# macOS
+.DS_Store
+
+# sbt specific
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+project/local-plugins.sbt
+.history
+.ensime
+.ensime_cache/
+.sbt-scripted/
+local.sbt
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/src/cilantro/README.md
+++ b/src/cilantro/README.md
@@ -1,0 +1,4 @@
+## Cilantro - a Scala 3 port of Mono.Cecil
+
+### Details
+In the works.

--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -1,0 +1,15 @@
+val scala3Version = "3.7.1"
+
+lazy val root = project
+  .in(file("."))
+  .settings(
+    name := "cilantro",
+
+    organization := "io.spicelabs",
+
+    version := "0.1.0-SNAPSHOT",
+
+    scalaVersion := scala3Version,
+
+    libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test
+  )

--- a/src/cilantro/project/build.properties
+++ b/src/cilantro/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.3

--- a/src/cilantro/src/main/scala/cilantro.metadata/CodedIndex.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/CodedIndex.scala
@@ -1,0 +1,30 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Metadata/CodedIndex.cs
+
+package io.spicelabs.cilantro.metadata
+
+enum CodedIndex {
+  case typeDefOrRef,
+  hasConstant,
+  hasCustomAttribute,
+  hasFieldMarshal,
+  hasDeclSecurity,
+  memberRefParent,
+  hasSemantics,
+  methodDefOrRef,
+  memberForwarded,
+  implementation,
+  customAttributeType,
+  resolutionScope,
+  typeOrMethodDef,
+  hasCustomDebugInformation,
+}

--- a/src/cilantro/src/main/scala/cilantro.metadata/MetadataToken.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/MetadataToken.scala
@@ -1,0 +1,43 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Metadata/MetadataToken.cs
+
+package io.spicelabs.cilantro
+
+import scala.language.strictEquality
+
+class MetadataToken(val token: Int) {
+    given CanEqual[MetadataToken, MetadataToken] = CanEqual.derived
+
+    def this(type_ : TokenType) = this(type_.value)
+    def this(type_ : TokenType, rid: Int) = this (type_.value | rid)
+
+    def RID = token & 0x00_ffffff
+    def tokenType =
+        val ott = TokenType.methodSpec
+        val tv = token & 0xff_000000
+        val ts = f"0x$tv%x"
+        TokenType.fromOrdinalValue(token & 0xff_000000)
+
+    override def equals(that: Any): Boolean = that match
+        case a: MetadataToken => this.token == a.token
+        case _ => false
+
+    override def hashCode(): Int = token.##
+
+    override def toString(): String =
+        val name = tokenType.toString()
+        f"[$name:0x$RID%04x]"
+}
+
+object MetadataToken {
+    val zero = MetadataToken(0)
+}

--- a/src/cilantro/src/main/scala/cilantro.metadata/TableHeap.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/TableHeap.scala
@@ -1,0 +1,71 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Metadata/TableHeap.cs
+
+package io.spicelabs.cilantro.metadata
+
+
+enum Table(val value: Byte)
+{
+    case module extends Table(0x00)
+    case typeRef extends Table(0x01)
+    case typeDef extends Table(0x02)
+    case fieldPtr extends Table(0x03)
+    case field extends Table(0x04)
+    case methodPtr extends Table(0x05)
+    case method extends Table(0x06)
+    case paramPtr extends Table(0x07)
+    case param extends Table(0x08)
+    case interfaceImpl extends Table(0x09)
+    case memberRef extends Table(0x0a)
+    case constant extends Table(0x0b)
+    case customAttribute extends Table(0x0c)
+    case fieldMarshal extends Table(0x0d)
+    case declSecurity extends Table(0x0e)
+    case classLayout extends Table(0x0f)
+    case fieldLayout extends Table(0x10)
+    case standAloneSig extends Table(0x11)
+    case eventMap extends Table(0x12)
+    case eventPtr extends Table(0x13)
+    case event extends Table(0x14)
+    case propertyMap extends Table(0x15)
+    case propertyPtr extends Table(0x16)
+    case property extends Table(0x17)
+    case methodSemantics extends Table(0x18)
+    case methodImpl extends Table(0x19)
+    case moduleRef extends Table(0x1a)
+    case typeSpec extends Table(0x1b)
+    case implMap extends Table(0x1c)
+    case fieldRVA extends Table(0x1d)
+    case encLog extends Table(0x1e)
+    case encMap extends Table(0x1f)
+    case assembly extends Table(0x20)
+    case assemblyProcessor extends Table(0x21)
+    case assemblyOS extends Table(0x22)
+    case assemblyRef extends Table(0x23)
+    case assemblyRefProcessor extends Table(0x24)
+    case assemblyRefOS extends Table(0x25)
+    case file extends Table(0x26)
+    case exportedType extends Table(0x27)
+    case manifestResource extends Table(0x28)
+    case nestedClass extends Table(0x29)
+    case genericParam extends Table(0x2a)
+    case methodSpec extends Table(0x2b)
+    case genericParamConstraint extends Table(0x2c)
+    case document extends Table(0x30)
+    case methodDebugInformation extends Table(0x31)
+    case localScope extends Table(0x32)
+    case localVariable extends Table(0x33)
+    case localConstant extends Table(0x34)
+    case importScope extends Table(0x35)
+    case stateMachineMethod extends Table(0x36)
+    case customDebugInformation extends Table(0x37)
+}

--- a/src/cilantro/src/main/scala/cilantro.metadata/TokenType.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/TokenType.scala
@@ -1,0 +1,57 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Metadata/TokenType.cs
+
+package io.spicelabs.cilantro
+
+import java.lang.*;
+
+enum TokenType(val value: Int) {
+  case module extends TokenType(0x00000000)
+  case typeRef extends TokenType(0x01000000)
+  case typeDef extends TokenType(0x02000000)
+  case field extends TokenType(0x04000000)
+  case method extends TokenType(0x06000000)
+  case param extends TokenType(0x08000000)
+  case interfaceImpl extends TokenType(0x09000000)
+  case memberRef extends TokenType(0x0a000000)
+  case customAttribute extends TokenType(0x0c000000)
+  case permission extends TokenType(0x0e000000)
+  case signature extends TokenType(0x11000000)
+  case event extends TokenType(0x14000000)
+  case property extends TokenType(0x17000000)
+  case moduleRef extends TokenType(0x1a000000)
+  case typeSpec extends TokenType(0x1b000000)
+  case assembly extends TokenType(0x20000000)
+  case assemblyRef extends TokenType(0x23000000)
+  case file extends TokenType(0x26000000)
+  case exportedType extends TokenType(0x27000000)
+  case manifestResource extends TokenType(0x28000000)
+  case genericParam extends TokenType(0x2a000000)
+  case methodSpec extends TokenType(0x2b000000)
+  case genericParamConstraint extends TokenType(0x2c000000)
+  case document extends TokenType(0x30000000)
+  case methodDebugInformation extends TokenType(0x31000000)
+  case localScope extends TokenType(0x32000000)
+  case localVariable extends TokenType(0x33000000)
+  case localConstant extends TokenType(0x34000000)
+  case importScope extends TokenType(0x35000000)
+  case stateMachineMethod extends TokenType(0x36000000)
+  case customDebugInformation extends TokenType(0x37000000)
+  case string extends TokenType(0x70000000)
+}
+
+object TokenType {
+  def fromOrdinalValue(value: Int) =
+    TokenType.values.find(x => {x.value == value}) match
+      case Some(result) => result
+      case None => throw IllegalArgumentException(s"value $value not found in TokenType")  
+}

--- a/src/cilantro/src/main/scala/cilantro.metadata/Utilities.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/Utilities.scala
@@ -1,0 +1,340 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Metadata/Utilities.cs
+
+package io.spicelabs.cilantro
+
+import io.spicelabs.cilantro.metadata.*;
+
+extension (b: Byte)
+    def asIntNoSign = b.toInt & 0xff
+
+extension (data: Array[Byte])
+    // returns a tuple with the first element being the data read
+    // and the second element being the new position after the read
+    def readCompressedInt32(position: Int) = 
+        val dataAtPos = data(position);
+        if ((dataAtPos & 0x80) == 0) {
+            (dataAtPos.asIntNoSign, position + 1)
+        } else if ((dataAtPos & 0x40) == 0) {
+            (((dataAtPos & ~0x80).toInt << 8) | data(position + 1).asIntNoSign, position + 2)
+        } else {
+            var i = (dataAtPos.asIntNoSign & ~0xc0) << 24
+            i |= data(position + 1).asIntNoSign << 16
+            i |= data(position + 2).asIntNoSign << 8
+            i |= data(position + 3).asIntNoSign
+            (i, position + 4)
+        }
+
+extension (self: CodedIndex)
+    def getMetadataToken(data: Int) =
+    self match
+        case CodedIndex.typeDefOrRef =>
+            val rid = data >>> 2
+            val tt = data & 3 match
+                case 0 => MetadataToken(TokenType.typeDef, rid)
+                case 1 => MetadataToken(TokenType.typeRef, rid)
+                case 2 => MetadataToken(TokenType.typeSpec, rid)
+                case _ => MetadataToken.zero
+
+        case CodedIndex.hasConstant =>
+            val rid = data >>> 2
+            val tt = data & 3 match
+                case 0 => MetadataToken(TokenType.field, rid)
+                case 1 => MetadataToken(TokenType.param, rid)
+                case 2 => MetadataToken(TokenType.property, rid)
+                case _ => MetadataToken.zero
+
+        case CodedIndex.hasCustomAttribute =>
+            var rid = data >>> 5
+            data & 31 match
+                case 0 => MetadataToken(TokenType.method, rid)
+                case 1 => MetadataToken(TokenType.field, rid)
+                case 2 => MetadataToken(TokenType.typeRef, rid)
+                case 3 => MetadataToken(TokenType.typeDef, rid)
+                case 4 => MetadataToken(TokenType.param, rid)
+                case 5 => MetadataToken(TokenType.interfaceImpl, rid)
+                case 6 => MetadataToken(TokenType.memberRef, rid)
+                case 7 => MetadataToken(TokenType.module, rid)
+                case 8 => MetadataToken(TokenType.permission, rid)
+                case 9 => MetadataToken(TokenType.property, rid)
+                case 10 => MetadataToken(TokenType.event, rid)
+                case 11 => MetadataToken(TokenType.signature, rid)
+                case 12 => MetadataToken(TokenType.moduleRef, rid)
+                case 13 => MetadataToken(TokenType.typeSpec, rid)
+                case 14 => MetadataToken(TokenType.assembly, rid)
+                case 15 => MetadataToken(TokenType.assemblyRef, rid)
+                case 16 => MetadataToken(TokenType.file, rid)
+                case 17 => MetadataToken(TokenType.exportedType, rid)
+                case 18 => MetadataToken(TokenType.manifestResource, rid)
+                case 19 => MetadataToken(TokenType.genericParam, rid)
+                case 20 => MetadataToken(TokenType.genericParamConstraint, rid)
+                case 21 => MetadataToken(TokenType.methodSpec, rid)
+                case _ => MetadataToken.zero
+        case CodedIndex.hasFieldMarshal =>
+            val tt = if (data & 1) == 0 then TokenType.field else TokenType.param
+            MetadataToken(tt, data >>> 1)
+        case CodedIndex.hasDeclSecurity =>
+            val rid = data >>> 2
+            data & 3 match
+                case 0 => MetadataToken(TokenType.typeDef, rid)
+                case 1 => MetadataToken(TokenType.method, rid)
+                case 2 => MetadataToken(TokenType.assembly, rid)
+                case _ => MetadataToken.zero
+        case CodedIndex.memberRefParent =>
+            val rid = data >>> 3
+            data & 7 match
+                case 0 => MetadataToken(TokenType.typeDef, rid)
+                case 1 => MetadataToken(TokenType.typeRef, rid)
+                case 2 => MetadataToken(TokenType.moduleRef, rid)
+                case 3 => MetadataToken(TokenType.method, rid)
+                case 4 => MetadataToken(TokenType.typeSpec, rid)
+                case _ => MetadataToken.zero
+        case CodedIndex.hasSemantics =>
+            val tt = if (data & 1) == 0 then TokenType.event else TokenType.property
+            MetadataToken(tt, data >>> 1)
+        case CodedIndex.methodDefOrRef =>
+            val tt = if (data & 1) == 0 then TokenType.method else TokenType.memberRef
+            MetadataToken(tt, data >>> 1)
+        case CodedIndex.memberForwarded =>
+            val tt = if (data & 1) == 0 then TokenType.field else TokenType.method
+            MetadataToken(tt, data >>> 1)
+        case CodedIndex.implementation =>
+            val rid = data >>> 2
+            data & 3 match
+                case 0 => MetadataToken(TokenType.file, rid)
+                case 1 => MetadataToken(TokenType.assemblyRef, rid)
+                case 2 => MetadataToken(TokenType.exportedType, rid)
+                case _ => MetadataToken.zero
+        case CodedIndex.customAttributeType =>
+            val rid = data >>> 3
+            data & 3 match
+                case 2 => MetadataToken(TokenType.method, rid)
+                case 3 => MetadataToken(TokenType.memberRef, rid)
+                case _ => MetadataToken.zero
+        case CodedIndex.resolutionScope =>
+            val tt = data & 3 match
+                case 0 => TokenType.module
+                case 1 => TokenType.moduleRef
+                case 2 => TokenType.assemblyRef
+                case 3 => TokenType.typeRef
+            MetadataToken(tt, data >> 2)
+        case CodedIndex.typeOrMethodDef =>
+            val tt = if (data & 1) == 0 then TokenType.typeDef else TokenType.method
+            MetadataToken(tt, data >> 1)
+        case CodedIndex.hasCustomDebugInformation =>
+            val rid = data >>> 5
+            data & 31 match
+                case 0 => MetadataToken(TokenType.method, rid)
+                case 1 => MetadataToken(TokenType.field, rid)
+                case 2 => MetadataToken(TokenType.typeRef, rid)
+                case 3 => MetadataToken(TokenType.typeDef, rid)
+                case 4 => MetadataToken(TokenType.param, rid)
+                case 5 => MetadataToken(TokenType.interfaceImpl, rid)
+                case 6 => MetadataToken(TokenType.memberRef, rid)
+                case 7 => MetadataToken(TokenType.module, rid)
+                case 8 => MetadataToken(TokenType.permission, rid)
+                case 9 => MetadataToken(TokenType.property, rid)
+                case 10 => MetadataToken(TokenType.event, rid)
+                case 11 => MetadataToken(TokenType.signature, rid)
+                case 12 => MetadataToken(TokenType.moduleRef, rid)
+                case 13 => MetadataToken(TokenType.typeSpec, rid)
+                case 14 => MetadataToken(TokenType.assembly, rid)
+                case 15 => MetadataToken(TokenType.assemblyRef, rid)
+                case 16 => MetadataToken(TokenType.file, rid)
+                case 17 => MetadataToken(TokenType.exportedType, rid)
+                case 18 => MetadataToken(TokenType.manifestResource, rid)
+                case 19 => MetadataToken(TokenType.genericParam, rid)
+                case 20 => MetadataToken(TokenType.genericParamConstraint, rid)
+                case 21 => MetadataToken(TokenType.methodSpec, rid)
+                case 22 => MetadataToken(TokenType.document, rid)
+                case 23 => MetadataToken(TokenType.localScope, rid)
+                case 24 => MetadataToken(TokenType.localVariable, rid)
+                case 25 => MetadataToken(TokenType.localConstant, rid)
+                case 26 => MetadataToken(TokenType.importScope, rid)
+                case _ => MetadataToken.zero
+    
+    def compressMetadataToken (token: MetadataToken) =
+        val ret: Option[Int] =
+            if token.RID == 0 then Some(0)
+            else
+                self match
+                    case CodedIndex.typeDefOrRef => 
+                        val rid = token.RID << 2
+                        token.tokenType match
+                            case TokenType.typeDef => Some(rid)
+                            case TokenType.typeRef => Some(rid | 1)
+                            case TokenType.typeSpec => Some(rid | 2)
+                            case _ => None
+                    case CodedIndex.hasConstant =>
+                        val rid = token.RID << 2
+                        token.tokenType match
+                            case TokenType.field => Some(rid)
+                            case TokenType.param => Some(rid | 1)
+                            case TokenType.property => Some(rid | 2)
+                            case _ => None
+                    case CodedIndex.hasCustomAttribute =>
+                        val rid = token.RID << 5
+                        token.tokenType match
+                            case TokenType.method => Some(rid)
+                            case TokenType.field => Some(rid | 1)
+                            case TokenType.typeRef => Some(rid |2)
+                            case TokenType.typeDef => Some(rid |3)
+                            case TokenType.param => Some(rid | 4)
+                            case TokenType.interfaceImpl => Some(rid | 5)
+                            case TokenType.memberRef => Some(rid | 6)
+                            case TokenType.module => Some(rid | 7)
+                            case TokenType.permission => Some(rid | 8)
+                            case TokenType.property => Some(rid | 9)
+                            case TokenType.event => Some(rid | 10)
+                            case TokenType.signature => Some(rid | 11)
+                            case TokenType.moduleRef => Some(rid | 12)
+                            case TokenType.typeSpec => Some(rid | 13)
+                            case TokenType.assembly => Some(rid | 14)
+                            case TokenType.assemblyRef => Some(rid | 15)
+                            case TokenType.file => Some(rid | 16)
+                            case TokenType.exportedType => Some(rid | 17)
+                            case TokenType.manifestResource => Some(rid | 18)
+                            case TokenType.genericParam => Some(rid | 19)
+                            case TokenType.genericParamConstraint => Some(rid | 20)
+                            case TokenType.methodSpec => Some(rid | 21)
+                            case _ => None                        
+                    case CodedIndex.hasFieldMarshal =>
+                        val rid = token.RID << 1
+                        token.tokenType match
+                            case TokenType.field => Some(rid)
+                            case TokenType.param => Some(rid | 1)
+                            case _ => None
+                    case CodedIndex.hasDeclSecurity =>
+                        val rid = token.RID << 2
+                        token.tokenType match
+                            case TokenType.typeDef => Some(rid)
+                            case TokenType.method => Some(rid | 1)
+                            case TokenType.assembly => Some(rid | 2)
+                            case _ => None
+                    case CodedIndex.memberRefParent =>
+                        val rid = token.RID << 3
+                        token.tokenType match
+                            case TokenType.typeDef => Some(rid)
+                            case TokenType.typeRef => Some(rid | 1)
+                            case TokenType.moduleRef => Some(rid | 2)
+                            case TokenType.method => Some(rid | 3)
+                            case TokenType.typeSpec => Some(rid | 4)
+                            case _ => None
+                    case CodedIndex.hasSemantics =>
+                        val rid = token.RID << 1
+                        token.tokenType match
+                            case TokenType.event => Some(rid)
+                            case TokenType.property => Some(rid | 1)
+                            case _ => None
+                    case CodedIndex.methodDefOrRef =>
+                        val rid = token.RID << 1
+                        token.tokenType match
+                            case TokenType.method => Some(rid)
+                            case TokenType.memberRef => Some(rid | 1)
+                            case _ => None
+                    case CodedIndex.memberForwarded =>
+                        val rid = token.RID << 1
+                        token.tokenType match
+                            case TokenType.field => Some(rid)
+                            case TokenType.method => Some(rid | 1)
+                            case _ => None
+                    case CodedIndex.implementation =>
+                        val rid = token.RID << 2
+                        token.tokenType match
+                            case TokenType.file => Some(rid)
+                            case TokenType.assemblyRef => Some(rid | 1)
+                            case TokenType.exportedType => Some(rid | 2)
+                            case _ => None                        
+                    case CodedIndex.customAttributeType =>
+                        val rid = token.RID << 3
+                        token.tokenType match
+                            case TokenType.method => Some(rid | 2)
+                            case TokenType.memberRef => Some(rid | 3)
+                            case _ => None                        
+                    case CodedIndex.resolutionScope =>
+                        val rid = token.RID << 2
+                        token.tokenType match
+                            case TokenType.module => Some(rid)
+                            case TokenType.moduleRef => Some(rid | 1)
+                            case TokenType.assemblyRef => Some(rid | 2)
+                            case TokenType.typeRef => Some(rid | 3)
+                            case _ => None                        
+                    case CodedIndex.typeOrMethodDef =>
+                        val rid = token.RID << 1
+                        token.tokenType match
+                            case TokenType.typeDef => Some(rid)
+                            case TokenType.method => Some(rid | 1)
+                            case _ => None
+                    case CodedIndex.hasCustomDebugInformation =>
+                        val rid = token.RID << 5
+                        token.tokenType match
+                            case TokenType.method => Some(rid)
+                            case TokenType.field => Some(rid | 1)
+                            case TokenType.typeRef => Some(rid |2)
+                            case TokenType.typeDef => Some(rid |3)
+                            case TokenType.param => Some(rid | 4)
+                            case TokenType.interfaceImpl => Some(rid | 5)
+                            case TokenType.memberRef => Some(rid | 6)
+                            case TokenType.module => Some(rid | 7)
+                            case TokenType.permission => Some(rid | 8)
+                            case TokenType.property => Some(rid | 9)
+                            case TokenType.event => Some(rid | 10)
+                            case TokenType.signature => Some(rid | 11)
+                            case TokenType.moduleRef => Some(rid | 12)
+                            case TokenType.typeSpec => Some(rid | 13)
+                            case TokenType.assembly => Some(rid | 14)
+                            case TokenType.assemblyRef => Some(rid | 15)
+                            case TokenType.file => Some(rid | 16)
+                            case TokenType.exportedType => Some(rid | 17)
+                            case TokenType.manifestResource => Some(rid | 18)
+                            case TokenType.genericParam => Some(rid | 19)
+                            case TokenType.genericParamConstraint => Some(rid | 20)
+                            case TokenType.methodSpec => Some(rid | 21)
+                            case TokenType.document => Some(rid | 22)
+                            case TokenType.localScope => Some(rid | 23)
+                            case TokenType.localVariable => Some(rid | 24)
+                            case TokenType.localConstant => Some(rid | 25)
+                            case TokenType.importScope => Some(rid | 26)
+                            case _ => None
+        ret match
+            case Some(value) => value
+            case None => throw IllegalArgumentException()
+    def getSize(counter: Table => Int) =
+        val (bits, table): (Int, Array[Table]) =
+            self match
+                case CodedIndex.typeDefOrRef => (2, Array(Table.typeDef, Table.typeRef, Table.typeSpec))
+                case CodedIndex.hasConstant => (2, Array(Table.field, Table.param, Table.property))
+                case CodedIndex.hasCustomAttribute => (5, Array(Table.method, Table.field, Table.typeRef, Table.typeDef,
+                        Table.param, Table.interfaceImpl, Table.memberRef,
+                        Table.module, Table.declSecurity, Table.property, Table.event, Table.standAloneSig, Table.moduleRef,
+                        Table.typeSpec, Table.assembly, Table.assemblyRef, Table.file, Table.exportedType,
+                        Table.manifestResource, Table.genericParam, Table.genericParamConstraint, Table.methodSpec))
+                case CodedIndex.hasFieldMarshal => (1, Array(Table.field, Table.param))
+                case CodedIndex.hasDeclSecurity => (2, Array(Table.typeDef, Table.method, Table.assembly))
+                case CodedIndex.memberRefParent => (3, Array(Table.typeDef, Table.typeRef, Table.moduleRef, Table.method,
+                        Table.typeSpec))
+                case CodedIndex.hasSemantics => (1, Array(Table.event, Table.property))
+                case CodedIndex.methodDefOrRef => (1, Array(Table.method, Table.memberRef))
+                case CodedIndex.memberForwarded => (1, Array(Table.field, Table.method))
+                case CodedIndex.implementation => (2, Array(Table.file, Table.assemblyRef, Table.exportedType))
+                case CodedIndex.customAttributeType => (3, Array(Table.method, Table.memberRef))
+                case CodedIndex.resolutionScope => (2, Array(Table.module, Table.moduleRef, Table.assemblyRef, Table.typeRef))
+                case CodedIndex.typeOrMethodDef => (1, Array(Table.typeDef, Table.method))
+                case CodedIndex.hasCustomDebugInformation => (5, Array(Table.method, Table.field, Table.typeRef,
+                        Table.typeDef, Table.param, Table.interfaceImpl, Table.memberRef,
+                        Table.module, Table.declSecurity, Table.property, Table.event, Table.standAloneSig, Table.moduleRef,
+                        Table.typeSpec, Table.assembly, Table.assemblyRef, Table.file, Table.exportedType,
+                        Table.manifestResource, Table.genericParam, Table.genericParamConstraint, Table.methodSpec,
+                        Table.document, Table.localScope, Table.localVariable, Table.localConstant, Table.importScope))
+
+        val max = table.map(counter).max
+        if max < (1 << (16 - bits)) then 2 else 4

--- a/src/cilantro/src/test/scala/cilantro.metadata/MetadataTokenTests.scala
+++ b/src/cilantro/src/test/scala/cilantro.metadata/MetadataTokenTests.scala
@@ -1,0 +1,16 @@
+
+import io.spicelabs.cilantro.*
+
+class MetadataTokenTests extends munit.FunSuite {
+    test("toString") {
+        var token = MetadataToken(type_ = TokenType.module)
+        var output = token.toString()
+        assertEquals(output, "[module:0x0000]")
+        token = MetadataToken(type_ = TokenType.methodSpec, rid = 0xbeef)
+        output = token.toString()
+        assertEquals(output, "[methodSpec:0xbeef]")
+        token = MetadataToken(type_ = TokenType.document, rid = 0xdead)
+        output = token.toString()
+        assertEquals(output, "[document:0xdead]")
+    }
+}


### PR DESCRIPTION
This PR includes a layout for the project(s).

The layout will be:
```
+src
|
+--cilantro - the Scala project for cilantro
|   |
|   +-project
|   +-src
|   +-target
+--dotnet-gen - the .NET sources for tests
```
With regards to the code that's present, I started porting some of the code from the Metadata directory to get myself back into Scala. They amount to some enums and some code that packs and unpacks them in various ways.
Comments are very much welcome on the Scala, especially `TokenType` which is an integer based enum with very specific values on each case.