### PR TITLE
Fixed crashes on reading

### DIFF
--- a/src/cilantro/src/main/scala/cilantro.PE/BinaryStreamReader.scala
+++ b/src/cilantro/src/main/scala/cilantro.PE/BinaryStreamReader.scala
@@ -25,8 +25,10 @@ class BinaryStreamReader(protected val fileInputStream: FileInputStream) {
         bb
     }
 
-    def position = fileInputStream.getChannel().position().toInt
-    def position_ (value: Int) = fileInputStream.getChannel().position(value.toLong & 0xffffffff)
+    
+
+    def position = byteBuffer.position()  //fileInputStream.getChannel().position().toInt
+    def position_=(value: Int) = byteBuffer.position(value) //fileInputStream.getChannel().position(value.toLong & 0xffffffff)
 
     def length = fileInputStream.getChannel().size().toInt
 

--- a/src/cilantro/src/main/scala/cilantro.metadata/PdbHeap.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/PdbHeap.scala
@@ -19,7 +19,13 @@ class PdbHeap(_data: Array[Byte]) extends Heap(_data)
     var typeSystemTables: Long = 0
     var typeSystemTableRows: Array[Int] = Array.emptyIntArray
 
-    def hasTable (table: Table) =
+    def hasTable (table: Table): Boolean =
         (typeSystemTables & (1L << table.value)) != 0
+    
+    def hasTable(tableOpt: Option[Table]): Boolean =
+        tableOpt match
+            case Some(table) => hasTable(table)
+            case None => false
+        
 }
 

--- a/src/cilantro/src/main/scala/cilantro.metadata/StringHeap.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/StringHeap.scala
@@ -13,6 +13,7 @@
 package io.spicelabs.cilantro.metadata
 import scala.collection.mutable.Map
 import java.nio.charset.StandardCharsets
+import scala.annotation.tailrec
 
 
 class StringHeap(data: Array[Byte]) extends Heap(data)
@@ -32,13 +33,16 @@ class StringHeap(data: Array[Byte]) extends Heap(data)
         return str
     
     protected def readStringAt(index: Int) : String =
-        var length = 0
-        for
-            i <- index to data.length
-            if (data(i) != 0)
-        do
-            length = length + 1
+        var length = strLength(index, 0)
 
         return String(data, index, length, StandardCharsets.UTF_8)
+    
+    @tailrec
+    private def strLength(index: Int, currLen: Int): Int =
+        if (index >= data.length || data(index) == 0)
+            currLen
+        else
+            strLength(index + 1, currLen + 1)
+
 }
 

--- a/src/cilantro/src/main/scala/cilantro.metadata/TableHeap.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/TableHeap.scala
@@ -79,6 +79,8 @@ object Table {
     Table.values.find(x => {x.value == value}) match
       case Some(result) => result
       case None => throw IllegalArgumentException(s"value $value not found in Table")  
+    def fromOrdinalValueMaybe(value: Int) =
+        Table.values.find(x => {x.value == value})
 }
 
 class TableInformation() {
@@ -97,6 +99,11 @@ class TableHeap (_data: Array[Byte]) extends Heap(_data) {
     def apply(table:Table) =
         tables(table.value)
 
-    def hasTable(table: Table) =
+    def hasTable(table: Table): Boolean =
         (valid & (1L << table.value)) != 0
+    def hasTable(someTable: Option[Table]): Boolean =
+        someTable match
+            case Some(table) => hasTable(table)
+            case None => false
+        
 }

--- a/src/cilantro/src/main/scala/cilantro.metadata/UserStringHeap.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/UserStringHeap.scala
@@ -22,7 +22,7 @@ class UserStringHeap(data: Array[Byte]) extends StringHeap(data) {
     val chars = Array.ofDim[Char](length / 2)
 
     var j = 0
-    for i <- start to start + length by 2 do
+    for i <- start until start + length by 2 do
         chars(j) = (data(i).toInt | ((data(i + 1).toInt & 0xff) << 8)).toChar
     
     String(chars)

--- a/src/cilantro/src/main/scala/cilantro/AssemblyNameDefinition.scala
+++ b/src/cilantro/src/main/scala/cilantro/AssemblyNameDefinition.scala
@@ -12,9 +12,7 @@
 
 package io.spicelabs.cilantro
 
-import java.lang.Runtime.Version
-
-class AssemblyNameDefinition(name: String, version: Version) extends AssemblyNameReference(name, version, MetadataToken(TokenType.assembly, 1)) {
+class AssemblyNameDefinition(name: String, version: CSVersion) extends AssemblyNameReference(name, version, MetadataToken(TokenType.assembly, 1)) {
 
     override def hash: Array[Byte] = Array.emptyByteArray
 

--- a/src/cilantro/src/main/scala/cilantro/CSVersion.scala
+++ b/src/cilantro/src/main/scala/cilantro/CSVersion.scala
@@ -1,0 +1,117 @@
+//
+// Author:
+//   Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+package io.spicelabs.cilantro
+
+class CSVersion(private val _major: Int, private val _minor: Int, private val _build:Int = -1, private val _revision: Int = -1) extends Ordered[CSVersion]{
+
+    def major = _major
+    def minor = _minor
+    def build = _build
+    def revision = _revision
+
+    override def compare(that: CSVersion): Int =
+        if (this._major != that._major)
+            if (this._major > that._major)
+                return 1
+            else
+                return -1
+        
+        if (this._minor != that._minor)
+            if (this._minor > that._minor)
+                return 1
+            else
+                return -1
+
+        if (this._build != that._build)
+            if (this._build > that._build)
+                return 1
+            else
+                return -1
+
+        if (this._revision != that._revision)
+            if (this._revision > that._revision)
+                return 1
+            else
+                return -1
+
+        0
+    
+    override def equals(that: Any): Boolean =
+        that match
+            case v : CSVersion => v._major == _major && v._minor == _minor && v._build == _build && v._revision == _revision
+            case _ => false
+    
+
+    override def hashCode(): Int =
+        var acc = 0
+        acc |= (_major & 0xf) << 28
+        acc |= (_minor & 0xff) << 20
+        acc |= (_build & 0xff) << 12
+        acc |= (_revision & 0xfff)
+        acc
+    
+    override def toString(): String =
+        if (_build == -1)
+            toString(2)
+        else if (_revision == -1)
+            toString(3)
+        else toString(4)
+
+    def toString(fieldCount: Int) =
+        val sb = StringBuilder()
+        fieldCount match
+            case 0 => ""
+            case 1 => _major.toString()
+            case 2 =>
+                sb.append(_major)
+                sb.append('.')
+                sb.append(_minor)
+                sb.toString()
+            case 3 =>
+                if (_build < 0)
+                    throw IllegalArgumentException("build")
+                sb.append(_major)
+                sb.append('.')
+                sb.append(_minor)
+                sb.append('.')
+                sb.append(_build)
+                sb.toString()
+            case 4 =>
+                if (_build < 0)
+                    throw IllegalArgumentException("build")
+                if (_revision < 0)
+                    throw IllegalArgumentException("revision")
+                sb.append(_major)
+                sb.append('.')
+                sb.append(_minor)
+                sb.append('.')
+                sb.append(_build)
+                sb.append('.')
+                sb.append(_revision)
+                sb.toString()
+            case _ => throw IllegalArgumentException("fieldCount")
+        
+}
+
+object CSVersion {
+    def parse(str: String): Option[CSVersion] =
+        val parts = str.split("\\.")
+        if (parts.length < 2 || parts.length > 4)
+            None
+        else
+            val (maj, min, b, r) = parts.length match
+                case 2 => (Integer.parseInt(parts(0)), Integer.parseInt(parts(1)), -1, -1)
+                case 3 => (Integer.parseInt(parts(0)), Integer.parseInt(parts(1)), Integer.parseInt(parts(2)), -1)
+                case 4 => (Integer.parseInt(parts(0)), Integer.parseInt(parts(1)), Integer.parseInt(parts(2)), Integer.parseInt(parts(3)))
+                case _ => throw IllegalArgumentException("str")
+            Some(new CSVersion(maj, min, b, r))            
+
+
+
+}

--- a/src/cilantro/src/main/scala/cilantro/Cil/Symbols.scala
+++ b/src/cilantro/src/main/scala/cilantro/Cil/Symbols.scala
@@ -143,7 +143,7 @@ class DefaultSymbolReaderProvider(private val throwIfNoSymbol: Boolean) extends 
         // var isNativePdb = true
 
         // boundary {
-        //     for i <- 1 to bytesHeader.length do
+        //     for i <- 1 until bytesHeader.length do
         //         if (bytesHeader(i) != nativePdbHeader.charAt(i).toByte)
         //             isNativePdb = false
         //             break()

--- a/src/cilantro/src/main/scala/cilantro/GenericParameter.scala
+++ b/src/cilantro/src/main/scala/cilantro/GenericParameter.scala
@@ -157,7 +157,7 @@ sealed class GenericParameterCollection(private val owner: GenericParameterProvi
     override def insert(index: Int, elem: GenericParameter): Unit =
         super.insert(index, elem)
         updateGenericParameter(elem, index)
-        for i <- index to length do
+        for i <- index + 1 until length do
             this(i)._position = i + 1
     
     override def update(index: Int, elem: GenericParameter): Unit =
@@ -175,7 +175,7 @@ sealed class GenericParameterCollection(private val owner: GenericParameterProvi
         elem._position = -1
         elem._type = GenericParameterType.`type`
 
-        for i <- index + 1 to length do
+        for i <- index until length do
             this(i)._position = i - 1
 
         elem

--- a/src/cilantro/src/main/scala/cilantro/ModuleDefinition.scala
+++ b/src/cilantro/src/main/scala/cilantro/ModuleDefinition.scala
@@ -147,7 +147,7 @@ sealed class ModuleDefinition() extends ModuleReference(null, MetadataToken(Toke
     var assembly_resolver: Disposable[AssemblyResolver] = null
     var metadata_resolver: MetadataResolverTrait = null
     // var type_system: TypeSystem // TODO
-    var reader: MetadataReader = null // TODO
+    var reader: MetadataReader = null
     var file_name: String = null
     var runtime_version: String = null
     var kind: ModuleKind = ModuleKind.dll
@@ -404,8 +404,7 @@ sealed class ModuleDefinition() extends ModuleReference(null, MetadataToken(Toke
         this.subsystem_minor = image.subSystemMinor
         this.file_name = image.fileName
         this.timestamp = image.timeStamp
-        // TODO
-//        this.reader = MetadataReader(this)
+        this.reader = MetadataReader(this)
 
 
     def close(): Unit =
@@ -490,7 +489,7 @@ sealed class ModuleDefinition() extends ModuleReference(null, MetadataToken(Toke
         // if (`type` == null)
         //     return null
         
-        // for i <- 1 to names.length do
+        // for i <- 1 until names.length do
         //     val nested_type = `type`.getNestedType(names(i))
         //     if (nested_type == null)
         //         return null
@@ -686,9 +685,11 @@ object ModuleDefinition {
         try
             readModule(Disposable.owned(stream), fileName, parameters)
         catch
-            case err: Exception =>
+            case err: Exception => {
                 stream.close()
                 throw err
+            }
+        finally { }
     
     def readModule(stream: FileInputStream): ModuleDefinition =
         val rp = ReaderParameters()
@@ -730,7 +731,7 @@ object ModuleDefinition {
                 return None
         
         private def pushReverse(items: Seq[TypeDefinition]) =
-            for i <- items.length - 1 to 0 do
+            for i <- items.length - 1 to 0 by -1 do
                 st.push(items(i))
     }
 
@@ -803,7 +804,7 @@ def getTimeStamp() =
 def fromHexString(s: String): Array[Byte] =
     val size = s.length / 2
     var arr = Array.ofDim[Byte](size)
-    for i <- 0 to s.length / 2 do
+    for i <- 0 until s.length / 2 do
         val pair = s.substring(2 * i, 2 * i + 2)
         val iVal = Integer.parseInt(pair, 16)
         arr(i) = iVal.toByte

--- a/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
+++ b/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
@@ -1,6 +1,8 @@
 import io.spicelabs.cilantro.*
 import java.nio.*
 import java.nio.file.*
+import java.io.FileInputStream
+import io.spicelabs.cilantro.PE.BinaryStreamReader
 
 class SmokeTests extends munit.FunSuite {
     test("smoke exists") {
@@ -10,11 +12,33 @@ class SmokeTests extends munit.FunSuite {
     }
 
     test("opens smoke file") {
-        intercept[IllegalArgumentException] {
-            var cwd = Paths.get(System.getProperty("user.dir"))
-            var smokePath = cwd.resolve("../../test-files/smoke/Smoke.dll")
-            var strPath = smokePath.toString()
-            var assem = AssemblyDefinition.readAssembly(strPath)
-        }
+        var cwd = Paths.get(System.getProperty("user.dir"))
+        var smokePath = cwd.resolve("../../test-files/smoke/Smoke.dll")
+        var strPath = smokePath.toString()
+        var assem = AssemblyDefinition.readAssembly(strPath)
+    }
+
+    test("open-seek-read") {
+        var cwd = Paths.get(System.getProperty("user.dir"))
+
+        var smokePath = cwd.resolve("../../test-files/smoke/Smoke.dll")
+        var strPath = smokePath.toString()
+
+        var filestream = new FileInputStream(strPath)
+        filestream.readNBytes(60)
+        filestream.getChannel().position(540)
+        var origBytes = filestream.readNBytes(512)
+        filestream.close()
+
+
+        filestream = new FileInputStream(strPath)
+    
+        var binstmreader = BinaryStreamReader(filestream)
+        binstmreader.readBytes(60)
+        binstmreader.position = 540
+        var newBytes = binstmreader.readBytes(512)
+
+        for i <- 0 until 512 do
+            assertEquals(origBytes(i), newBytes(i), clue = s"diff at index $i")
     }
 }


### PR DESCRIPTION
The previous PR added a ton of files and wouldn't actually read an assembly.

This PR addresses that and in the process of going through basic reading, I discovered that:

1. Scala as a language makes for loops painful. Had to modify all the loops to use `until` instead of `to` and in some cases remove the loop entirely as the guard was violating the principle of least astonishment
2. There was a bug in i/o handling. Pro-tip - if you have an adapted stream, watch when you change the stream position
3. The Java Version object is so utterly broken that it was easier to create a port of the C# version object rather than try to work around that Version doesn't have a constructor and the parse factory won't parse "1" "1.0" "1.0.0" or "1.0.0.0" and this is considered normal.

Added an i/o unit test and took the intercept off the smoke test.