### PR TITLE
now reading custom attributes

### DIFF
--- a/src/cilantro/src/main/scala/cilantro.PE/ByteBuffer.scala
+++ b/src/cilantro/src/main/scala/cilantro.PE/ByteBuffer.scala
@@ -66,15 +66,15 @@ open class ByteBuffer (var buffer: Array[Byte]) {
         val l1 = readInt32().toLong
         l0 | (l1 << 32)
 
-    def readCompressedUInt32() =
+    def readCompressedUInt32(): Int =
         val first = readByte()
         if ((first & 0x80) == 0)
-            first.toInt
+            return first.toInt
         
         if ((first & 0x40) == 0)
-            ((first & 0x7f).toInt << 8) | readByteAsUnsignedInt()
+            return ((first & 0x7f).toInt << 8) | readByteAsUnsignedInt()
         
-        ((first.toInt & 0x3f) << 24) | (readByteAsUnsignedInt() << 16) | (readByteAsUnsignedInt() << 8) | readByteAsUnsignedInt()
+        return ((first.toInt & 0x3f) << 24) | (readByteAsUnsignedInt() << 16) | (readByteAsUnsignedInt() << 8) | readByteAsUnsignedInt()
 
     def readCompressedInt32() : Int =
         val b = buffer(position)

--- a/src/cilantro/src/main/scala/cilantro.PE/Image.scala
+++ b/src/cilantro/src/main/scala/cilantro.PE/Image.scala
@@ -63,9 +63,10 @@ sealed class Image extends AutoCloseable {
         var size = coded_index_sizes(index)
         if (size != 0)
             size
-        size = coded_index.getSize(counter)
-        coded_index_sizes(index) = size
-        size
+        else
+            size = coded_index.getSize(counter)
+            coded_index_sizes(index) = size
+            size
     
     def resolveVirtualAddress(rva: Int) =
         val section = getSectionAtVirtualAddress(rva)

--- a/src/cilantro/src/main/scala/cilantro.metadata/ElementType.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/ElementType.scala
@@ -58,6 +58,15 @@ enum ElementType (val value: Byte) {
 
   def asMetadataType: MetadataType =
     MetadataType.fromOrdinalValue(value)
+  
+  def isPrimitive =
+    this match
+      case ElementType.boolean | ElementType.char | ElementType.i | ElementType.u
+      | ElementType.i1 | ElementType.u1 | ElementType.i2 | ElementType.u2
+      | ElementType.i4 | ElementType.u4 | ElementType.i8 | ElementType.u8
+      | ElementType.r4 | ElementType.r8 => true
+      case _ => false
+    
 }
 
 object ElementType {

--- a/src/cilantro/src/main/scala/cilantro/Cil/VariableDefinition.scala
+++ b/src/cilantro/src/main/scala/cilantro/Cil/VariableDefinition.scala
@@ -1,0 +1,21 @@
+// Derived from //
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil.Cil/VariableDefinition.cs
+
+package io.spicelabs.cilantro.cil
+
+import io.spicelabs.cilantro.TypeReference
+
+sealed class VariableDefinition(variableType: TypeReference) extends VariableReference(variableType) {
+    def isPinned = _variable_type.isPinned
+
+    override def resolve(): VariableDefinition = this
+}

--- a/src/cilantro/src/main/scala/cilantro/Cil/VariableReference.scala
+++ b/src/cilantro/src/main/scala/cilantro/Cil/VariableReference.scala
@@ -1,0 +1,31 @@
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/TypeParser.cs
+
+package io.spicelabs.cilantro.cil
+
+import io.spicelabs.cilantro.TypeReference
+
+abstract class VariableReference(protected var _variable_type: TypeReference) {
+    var _index = -1
+
+    def variableType = _variable_type
+    def variableType_=(value: TypeReference) = _variable_type = value
+
+    def index = _index
+
+    def resolve(): VariableDefinition
+
+    override def toString(): String =
+        if (index >= 0)
+            s"V_$index"
+        else
+            ""
+}

--- a/src/cilantro/src/main/scala/cilantro/CustomAttributeProvider.scala
+++ b/src/cilantro/src/main/scala/cilantro/CustomAttributeProvider.scala
@@ -24,5 +24,6 @@ trait CustomAttributeProvider extends MetadataTokenProvider {
     def getCustomAttributes(variable: ArrayBuffer[CustomAttribute], module: ModuleDefinition) =
         if (module.hasImage)
             module.read(variable, this, (provider, reader) => reader.readCustomAttributes(provider))
-        ArrayBuffer.empty[CustomAttribute]
+        else
+            ArrayBuffer.empty[CustomAttribute]
 }

--- a/src/cilantro/src/main/scala/cilantro/ExportedType.scala
+++ b/src/cilantro/src/main/scala/cilantro/ExportedType.scala
@@ -1,0 +1,153 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/ExportedType.cs
+
+package io.spicelabs.cilantro
+
+import io.spicelabs.cilantro.MemberDefinition.getMaskedAttributes
+import io.spicelabs.cilantro.MemberDefinition.setMaskedAttributes
+import io.spicelabs.cilantro.MemberDefinition.getAttributes
+import io.spicelabs.cilantro.MemberDefinition.setAttributes
+import javax.naming.OperationNotSupportedException
+
+sealed class ExportedType(namespace: String, __name: String, module: ModuleDefinition, __scope: MetadataScope) extends MetadataTokenProvider {
+    private var _namespace: String = namespace
+    private var _name: String = __name
+    private var _attributes = 0
+    private var _scope: MetadataScope = __scope
+    private var _module: ModuleDefinition = module
+    private var _identifier = 0
+    private var _declaring_type: ExportedType = null
+    var _token: MetadataToken = null
+    var _reentrancyGuard = false
+
+    def nameSpace = _namespace
+    def nameSpace_=(value: String) = _namespace = value
+
+    def name = _name
+    def name_=(value: String) = _name = value
+
+    def attributes = _attributes
+    def attributes_=(value: Int) = _attributes = value
+
+    def scope: MetadataScope = if _declaring_type != null then _declaring_type.scope else _scope
+    def scope_=(value: MetadataScope): Unit =
+        if (_declaring_type != null)
+            _declaring_type.scope = value
+        else
+            _scope = value
+    
+    def declaringType = _declaring_type
+    def declaringType_=(value: ExportedType) = _declaring_type = value
+
+    override def metadataToken: MetadataToken = _token
+    override def metadataToken_=(value: MetadataToken): Unit = _token = value
+
+    def identifier = _identifier
+    def identifier_=(value: Int) = _identifier = value
+
+    def isNotPublic = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.notPublic.value)
+    def isNotPublic_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.notPublic.value, value)
+
+    def isPublic = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.public.value)
+    def isPublic_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.public.value, value)
+
+    def isNestedPublic = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPublic.value)
+    def isNestedPublic_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPublic.value, value)
+
+    def isNestedPrivate = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPrivate.value)
+    def isNestedPrivate_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPrivate.value, value)
+
+    def isNestedFamily = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamily.value)
+    def isNestedFamily_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamily.value, value)
+
+    def isNestedAssembly = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedAssembly.value)
+    def isNestedAssembly_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedAssembly.value, value)
+
+    def isNestedFamilyAndAssembly = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamANDAssem.value)
+    def isNestedFamilyAndAssembly_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamANDAssem.value, value)
+
+    def isNestedFamilyOrAssembly = getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamORAssem.value)
+    def isNestedFamilyOrAssembly_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamORAssem.value, value)
+
+    def isAutoLayout = getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.autoLayout.value)
+    def isAutoLayout_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.autoLayout.value, value)
+
+    def isSequentialLayout = getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.sequentialLayout.value)
+    def isSequentialLayout_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.sequentialLayout.value, value)
+
+    def isExplicitLayout = getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.explicitLayout.value)
+    def isExplicitLayout_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.explicitLayout.value, value)
+
+    def isClass = getMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.`class`.value)
+    def isClass_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.`class`.value, value)
+
+    def isInterface = getMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.interface.value)
+    def isInterface_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.interface.value, value)
+
+    def isAbstract = getAttributes(_attributes, TypeAttributes.`abstract`.value)
+    def isAbstract_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.`abstract`.value, value)
+
+    def isSealed = getAttributes(_attributes, TypeAttributes.`sealed`.value)
+    def isSealed_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.`sealed`.value, value)
+
+    def isSpecialName = getAttributes(_attributes, TypeAttributes.specialName.value)
+    def isSpecialName_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.specialName.value, value)
+
+    def isImport = getAttributes(_attributes, TypeAttributes.`import`.value)
+    def isImport_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.`import`.value, value)
+
+    def isSerializable = getAttributes(_attributes, TypeAttributes.serializable.value)
+    def isSerializable_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.serializable.value, value)
+
+    def isAnsiClass = getMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.ansiClass.value)
+    def isAnsiClass_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.ansiClass.value, value)
+
+    def isUnicodeClass = getMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.unicodeClass.value)
+    def isUnicodeClass_=(value: Boolean) = _attributes = setMaskedAttributes(_attributes, TypeAttributes.unicodeClass.value, TypeAttributes.ansiClass.value, value)
+
+    def isBeforeFieldInit = getAttributes(_attributes, TypeAttributes.beforeFieldInit.value)
+    def isBeforeFieldInit_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.beforeFieldInit.value, value)
+
+    def isRuntimeSpecialName = getAttributes(_attributes, TypeAttributes.rtSpecialName.value)
+    def isRuntimeSpecialName_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.rtSpecialName.value, value)
+
+    def hasSecurity = getAttributes(_attributes, TypeAttributes.hasSecurity.value)
+    def hasSecurity_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.hasSecurity.value, value)
+
+    def isForwarder = getAttributes(_attributes, TypeAttributes.forwarder.value)
+    def isForwarder_=(value: Boolean) = _attributes = setAttributes(_attributes, TypeAttributes.forwarder.value, value)
+
+    def fullName:String =
+        val fullname = if (nameSpace == null || nameSpace.length() == 0) then _name else nameSpace + '.' + nameSpace
+
+        if (_declaring_type != null)
+            _declaring_type.fullName + "/" + fullname
+        else
+            fullname
+    
+    override def toString(): String = fullName
+
+    def resolve(): TypeDefinition =
+        if (_reentrancyGuard)
+            throw OperationNotSupportedException(s"Circularity when resolving exported type: '$this'")
+        _reentrancyGuard = true
+        try
+            _module.resolve(createReference())
+        finally
+            _reentrancyGuard = false
+
+    def createReference(): TypeReference =
+        val typeref = TypeReference(nameSpace, _name, _module, scope)
+        typeref.declaringType = if _declaring_type != null then _declaring_type.createReference() else null
+        typeref
+
+}

--- a/src/cilantro/src/main/scala/cilantro/Extensions.scala
+++ b/src/cilantro/src/main/scala/cilantro/Extensions.scala
@@ -8,8 +8,9 @@
 
 package io.spicelabs.cilantro
 
+
 object AnyExtension {
     extension (a: Any) {
-        def as[T >: Null]: T = if a.isInstanceOf[T] then a.asInstanceOf[T] else null
+        inline def as[T >: Null]: T = if a.isInstanceOf[T] then a.asInstanceOf[T] else null.asInstanceOf[T]
     }
 }

--- a/src/cilantro/src/main/scala/cilantro/GenericParameter.scala
+++ b/src/cilantro/src/main/scala/cilantro/GenericParameter.scala
@@ -166,7 +166,7 @@ sealed class GenericParameterCollection(private val owner: GenericParameterProvi
         super.insert(index, elem)
         updateGenericParameter(elem, index)
         for i <- index + 1 until length do
-            this(i)._position = i + 1
+            this(i)._position = i
     
     override def update(index: Int, elem: GenericParameter): Unit =
         super.update(index, elem)
@@ -184,7 +184,7 @@ sealed class GenericParameterCollection(private val owner: GenericParameterProvi
         elem._type = GenericParameterType.`type`
 
         for i <- index until length do
-            this(i)._position = i - 1
+            this(i)._position = i
 
         elem
 }

--- a/src/cilantro/src/main/scala/cilantro/GenericParameterResolver.scala
+++ b/src/cilantro/src/main/scala/cilantro/GenericParameterResolver.scala
@@ -1,0 +1,155 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/GenericParameterResolver.cs
+
+package io.spicelabs.cilantro
+
+import io.spicelabs.cilantro.AnyExtension.as
+import io.spicelabs.cilantro.cil.VariableReference
+import javax.naming.OperationNotSupportedException
+
+sealed class GenericParameterResolver {
+}
+
+object GenericParameterResolver {
+    def resolveReturnTypeIfNeeded(methodReference: MethodReference): TypeReference =
+        if (methodReference.declaringType.isArray && methodReference.name == "Get")
+            return methodReference.returnType
+        
+        val genericInstanceMethod = methodReference.as[GenericInstanceMethod]
+        val declaringGenericInstanceType = methodReference.declaringType.as[GenericInstanceType]
+
+        if (genericInstanceMethod == null && declaringGenericInstanceType == null)
+            return methodReference.returnType
+        
+        resolveIfNeeded(genericInstanceMethod, declaringGenericInstanceType, methodReference.returnType)
+    
+    def resolveFieldTypeIfNeeded(fieldReference: FieldReference) =
+        resolveIfNeeded(null, fieldReference.declaringType.as[GenericInstanceType], fieldReference.fieldType)
+
+    def resolveParameterTypeIfNeeded(method: MethodReference, parameter: ParameterReference): TypeReference =
+        val genericInstanceMethod = method.as[GenericInstanceMethod]
+        val declaringGenericInstanceType = method.declaringType.as[GenericInstanceType]
+
+        if (genericInstanceMethod == null && declaringGenericInstanceType == null)
+            return parameter.parameterType
+        
+        resolveIfNeeded(genericInstanceMethod, declaringGenericInstanceType, parameter.parameterType)
+
+    def resolveVariableTypeIfNeeded(method: MethodReference, variable: VariableReference): TypeReference =
+        val genericInstanceMethod = method.as[GenericInstanceMethod]
+        val declaringGenericInstanceType = method.declaringType.as[GenericInstanceType]
+
+        if (genericInstanceMethod == null && declaringGenericInstanceType == null)
+            return variable.variableType
+
+        resolveIfNeeded(genericInstanceMethod, declaringGenericInstanceType, variable.variableType)
+    
+    private def resolveIfNeeded(genericInstanceMethod: GenericInstance, declaringType: GenericInstance, parameterType: TypeReference): TypeReference =
+        val byRefType = parameterType.as[ByReferenceType]
+        if (byRefType != null)
+            return resolveIfNeeded(genericInstanceMethod, declaringType, byRefType)
+        
+        val arrayType = parameterType.as[ArrayType]
+        if (arrayType != null)
+            return resolveIfNeeded(genericInstanceMethod, declaringType, arrayType)
+        
+        val genericInstanceType = parameterType.as[GenericInstanceType]
+        if (genericInstanceType != null)
+            return resolveIfNeeded(genericInstanceMethod, declaringType, genericInstanceType)
+
+        val genericParameter = parameterType.as[GenericParameter]
+        if (genericParameter != null)
+            return resolveIfNeeded(genericInstanceMethod, declaringType, genericParameter)
+        
+        val requiredModifierType = parameterType.as[RequiredModifierType]
+        if (requiredModifierType != null && containsGenericParameters(requiredModifierType))
+            return resolveIfNeeded(genericInstanceMethod, declaringType, requiredModifierType)
+        
+        if (containsGenericParameters(parameterType))
+            throw IllegalArgumentException("Unexpected generic parameter.")
+        
+        parameterType
+
+    private def resolveIfNeeded(genericInstanceMethod: GenericInstance, genericInstanceType: GenericInstance, genericParameterElement: GenericParameter): TypeReference =
+        if genericParameterElement.metadataType == MetadataType.mVar then
+            if genericInstanceMethod != null then genericInstanceMethod.genericArguments(genericParameterElement.position) else genericParameterElement
+        else
+            genericInstanceType.genericArguments(genericParameterElement.position)
+    
+    private def resolveIfNeeded(genericInstanceMethod: GenericInstance, genericInstanceType: GenericInstance, arrayType: ArrayType): ArrayType =
+        ArrayType(resolveIfNeeded(genericInstanceMethod, genericInstanceType, arrayType.elementType), arrayType.rank)
+    
+    private def resolveIfNeeded(genericInstanceMethod: GenericInstance, genericInstanceType: GenericInstance, byReferenceType: ByReferenceType): ByReferenceType =
+        ByReferenceType(resolveIfNeeded(genericInstanceMethod, genericInstanceType, byReferenceType.elementType))
+
+    private def resolveIfNeeded(genericInstanceMethod: GenericInstance, genericInstanceType: GenericInstance, genericInstanceType1: GenericInstanceType): GenericInstanceType =
+        if (!containsGenericParameters(genericInstanceType1))
+            return genericInstanceType1
+
+        val newGenericInstance = GenericInstanceType(genericInstanceType1.elementType)
+
+        for genericArgument <- genericInstanceType1.genericArguments do
+            if (!genericArgument.isGenericParameter)
+                newGenericInstance.genericArguments.addOne(resolveIfNeeded(genericInstanceMethod, genericInstanceType, genericArgument))
+            else
+                val genParam = genericArgument.asInstanceOf[GenericParameter]
+                genParam.`type` match
+                    case GenericParameterType.`type` =>
+                        if (genericInstanceType == null)
+                            throw OperationNotSupportedException()
+                        newGenericInstance.genericArguments.addOne(genericInstanceType.genericArguments(genParam.position))
+                    case GenericParameterType.method =>
+                        if (genericInstanceMethod == null)
+                            newGenericInstance.genericArguments.addOne(genParam)
+                        else
+                            newGenericInstance.genericArguments.addOne(genericInstanceMethod.genericArguments(genParam.position))
+        newGenericInstance
+    
+    private def containsGenericParameters(typeReference: TypeReference): Boolean =
+        val genericParameter = typeReference.as[GenericParameter]
+        if (genericParameter != null)
+            return true
+        
+        val arrayType = typeReference.as[ArrayType]
+        if (arrayType != null)
+            return containsGenericParameters(arrayType.elementType)
+        
+        val pointerType = typeReference.as[PointerType]
+        if (pointerType != null)
+            return containsGenericParameters(pointerType.elementType)
+
+        val byReferenceType = typeReference.as[ByReferenceType]
+        if (byReferenceType != null)
+            return containsGenericParameters(byReferenceType.elementType)
+        
+        val sentinelType = typeReference.as[SentinelType]
+        if (sentinelType != null)
+            return containsGenericParameters(sentinelType.elementType)
+        
+        val pinnedType = typeReference.as[PinnedType]
+        if (pinnedType != null)
+            return containsGenericParameters(pinnedType.elementType)
+        
+        val requiredModifierType = typeReference.as[RequiredModifierType]
+        if (requiredModifierType != null)
+            return containsGenericParameters(requiredModifierType.elementType)
+        
+        val genericInstance = typeReference.as[GenericInstanceType]
+        if (genericInstance != null)
+            return genericInstance.genericArguments.exists(containsGenericParameters)
+        
+        if (typeReference.isInstanceOf[TypeSpecification])
+            throw OperationNotSupportedException()
+        return false
+
+                        
+}

--- a/src/cilantro/src/main/scala/cilantro/Import.scala
+++ b/src/cilantro/src/main/scala/cilantro/Import.scala
@@ -254,7 +254,7 @@ class DefaultMetadataImport(protected val module: ModuleDefinition) extends Meta
                 if (!method.hasParameters)
                     reference
                 else
-                    reference._parameters = ParameterDefinitionCollection()
+                    reference._parameters = ParameterDefinitionCollection(reference)
                     reference._parameters.addAll(method.parameters.map((p) => ParameterDefinition(importType(p.parameterType, context))))
                     reference
             finally

--- a/src/cilantro/src/main/scala/cilantro/MemberReference.scala
+++ b/src/cilantro/src/main/scala/cilantro/MemberReference.scala
@@ -22,7 +22,7 @@ abstract class MemberReference(var _name : String) extends MetadataTokenProvider
     var token: MetadataToken = null
     var projection: Any = null
 
-    def name = _name
+    def name: String = _name
     def name_=(value: String) = {
         if (isWindowsRuntimeProjection && value != name)
             throw new OperationNotSupportedException()

--- a/src/cilantro/src/main/scala/cilantro/MetadataResolver.scala
+++ b/src/cilantro/src/main/scala/cilantro/MetadataResolver.scala
@@ -21,5 +21,8 @@ class ResolutionException extends  Exception {
     
 }
 
-trait MetadataResolverTrait { // TODO
+trait MetadataResolverTrait {
+    def resolve(`type`: TypeReference): TypeDefinition
+    def resolve(field: FieldReference): FieldDefinition
+    def resolve(method: MethodReference): MethodDefinition
 }

--- a/src/cilantro/src/main/scala/cilantro/MetadataSystem.scala
+++ b/src/cilantro/src/main/scala/cilantro/MetadataSystem.scala
@@ -45,8 +45,8 @@ sealed class MetadataSystem {
     var _fieldMarshals: HashMap[MetadataToken, Int] = null
     var _constants: HashMap[MetadataToken, Row2[ElementType, Int]] = null
     var _overrides: HashMap[Int, ArrayBuffer[MetadataToken]] = null
-    var _customAttributes: HashMap[MetadataToken, Array[Range]] = null
-    var _securityDeclarations: HashMap[MetadataToken, Array[Range]] = null
+    var _customAttributes: HashMap[MetadataToken, ArrayBuffer[Range]] = null
+    var _securityDeclarations: HashMap[MetadataToken, ArrayBuffer[Range]] = null
     var _events: HashMap[Int, Range] = null
     var _properties: HashMap[Int, Range] = null
     // TODO

--- a/src/cilantro/src/main/scala/cilantro/MethodCallingConvention.scala
+++ b/src/cilantro/src/main/scala/cilantro/MethodCallingConvention.scala
@@ -22,3 +22,10 @@ enum MethodCallingConvention(val value: Byte) {
   case unmanaged extends MethodCallingConvention(0x9)
   case generic extends MethodCallingConvention(0x10)
 }
+object MethodCallingConvention {
+  def fromOrdinalValue(value: Int) =
+    MethodCallingConvention.values.find(x => {x.value == value}) match
+      case Some(result) => result
+      case None => throw IllegalArgumentException(s"value $value not found in MethodCallingConvention")  
+
+}

--- a/src/cilantro/src/main/scala/cilantro/MethodDefinition.scala
+++ b/src/cilantro/src/main/scala/cilantro/MethodDefinition.scala
@@ -18,9 +18,8 @@ import javax.naming.OperationNotSupportedException
 
 
 // TODO ctor parameters
-class MethodDefinition extends MethodReference with MemberDefinition {
+class MethodDefinition(_name: String, private var _attributes: Char, returnType: TypeReference) extends MethodReference(_name, returnType) with MemberDefinition {
     this.token = MetadataToken(TokenType.method)
-    private var _attributes: Char = 0
     private var _impl_attributes: Char = 0
 
     var _sem_attrs_ready: Boolean = false
@@ -41,10 +40,11 @@ class MethodDefinition extends MethodReference with MemberDefinition {
     // var _debug_info: MethodDebugInformation = null
     var _custom_infos: ArrayBuffer[CustomDebugInformation] = null
 
-    override def name =
-        super.name
+    def this() =
+        this("", 0, null)
+
     override def name_=(value: String) =
-        if (isWindowsRuntimeProjection && value != super.name)
+        if (isWindowsRuntimeProjection && value != name)
             throw OperationNotSupportedException()
         super.name = value
     

--- a/src/cilantro/src/main/scala/cilantro/MethodReference.scala
+++ b/src/cilantro/src/main/scala/cilantro/MethodReference.scala
@@ -4,16 +4,16 @@ import scala.collection.mutable.ArrayBuffer
 import javax.naming.OperationNotSupportedException
 import io.spicelabs.cilantro.AnyExtension.as
 
-class MethodReference extends MemberReference with MethodSignature with GenericParameterProvider with GenericContext { // TODO
-    private var _module: ModuleDefinition = null;
-
+class MethodReference(name: String, _returnType: TypeReference, _declaring_type: TypeReference = null) extends MemberReference(name) with MethodSignature with GenericParameterProvider with GenericContext { // TODO
     var _parameters: ParameterDefinitionCollection = null
 
-    private var _return_type:MethodReturnType = null
+    private var _return_type:MethodReturnType = MethodReturnType(this)
+    _return_type.returnType = _returnType
+    this.token = MetadataToken(TokenType.memberRef)
+    this.declaringType = _declaring_type
 
-    override def hasImage = false
-
-    override def module = _module
+    def this() =
+        this(null, null)
 
     private var _has_this = false
     private var _explicit_this = false
@@ -35,7 +35,7 @@ class MethodReference extends MemberReference with MethodSignature with GenericP
 
     def parameters =
         if (_parameters == null)
-            _parameters = ParameterDefinitionCollection(/* this */) // TODO
+            _parameters = ParameterDefinitionCollection(this)
         _parameters
     
 

--- a/src/cilantro/src/main/scala/cilantro/NativeType.scala
+++ b/src/cilantro/src/main/scala/cilantro/NativeType.scala
@@ -1,0 +1,62 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/NativeType.cs
+
+package io.spicelabs.cilantro
+
+enum NativeType(val value: Int) {
+  case none extends NativeType(0x66)
+  case boolean extends NativeType(0x02)
+  case i1 extends NativeType(0x03)
+  case u1 extends NativeType(0x04)
+  case i2 extends NativeType(0x05)
+  case u2 extends NativeType(0x06)
+  case i4 extends NativeType(0x07)
+  case u4 extends NativeType(0x08)
+  case i8 extends NativeType(0x09)
+  case u8 extends NativeType(0x0a)
+  case r4 extends NativeType(0x0b)
+  case r8 extends NativeType(0x0c)
+  case lpStr extends NativeType(0x14)
+  case int extends NativeType(0x1f)
+  case uint extends NativeType(0x20)
+  case func extends NativeType(0x26)
+  case array extends NativeType(0x2a)
+  case currency extends NativeType(0x0f)
+  case bStr extends NativeType(0x13)
+  case lpWStr extends NativeType(0x15)
+  case lpTStr extends NativeType(0x16)
+  case fixedSysString extends NativeType(0x17)
+  case iUnknown extends NativeType(0x19)
+  case iDispatch extends NativeType(0x1a)
+  case struct extends NativeType(0x1b)
+  case intF extends NativeType(0x1c)
+  case safeArray extends NativeType(0x1d)
+  case fixedArray extends NativeType(0x1e)
+  case byValStr extends NativeType(0x22)
+  case ansiBStr extends NativeType(0x23)
+  case tBStr extends NativeType(0x24)
+  case variantBool extends NativeType(0x25)
+  case asAny extends NativeType(0x28)
+  case lpStruct extends NativeType(0x2b)
+  case customMarshaler extends NativeType(0x2c)
+  case error extends NativeType(0x2d)
+  case max extends NativeType(0x50)
+}
+
+object NativeType {
+  def fromOrdinalValue(value: Int): NativeType =
+    NativeType.values.find(x => {x.value == value}) match
+      case Some(result) => result
+      case None => throw IllegalArgumentException(s"value $value not found in NativeType")
+  def fromOrdinalValue(value: Byte): NativeType =
+    fromOrdinalValue(value.toInt & 0xff)
+}

--- a/src/cilantro/src/main/scala/cilantro/ParameterDefinitionCollection.scala
+++ b/src/cilantro/src/main/scala/cilantro/ParameterDefinitionCollection.scala
@@ -14,7 +14,34 @@
 package io.spicelabs.cilantro
 
 import scala.collection.mutable.ArrayBuffer
+import io.spicelabs.cilantro.metadata.Table
 
-class ParameterDefinitionCollection extends ArrayBuffer[ParameterDefinition] {
-  
+class ParameterDefinitionCollection(val _method: MethodSignature, capacity:Int = 0) extends ArrayBuffer[ParameterDefinition]() {
+    override def addOne(elem: ParameterDefinition): this.type =
+        val retval = super.addOne(elem)
+        elem._method = _method
+        elem._index = this.length - 1
+        this
+    
+    override def insert(index: Int, elem: ParameterDefinition): Unit =
+        super.insert(index, elem)
+        elem._method = _method
+        elem._index = index
+        for i <- index + 1 until length do
+            this(i)._index = i
+    
+    override def update(index: Int, elem: ParameterDefinition): Unit =
+        super.update(index, elem)
+        elem._method = _method
+        elem._index = index
+    
+    override def remove(index: Int): ParameterDefinition =
+        val elem = super.remove(index)
+        elem._method = null
+        elem._index = -1
+
+        for i <- index until length do
+            this(i)._index = i
+        elem
+
 }

--- a/src/cilantro/src/main/scala/cilantro/TargetRuntime.scala
+++ b/src/cilantro/src/main/scala/cilantro/TargetRuntime.scala
@@ -14,4 +14,22 @@ package io.spicelabs.cilantro
 
 enum TargetRuntime {
   case net_1_0, net_1_1, net_2_0, net_4_0
+  def runtimeVersionString() =
+    this match
+      case TargetRuntime.net_1_0 => "v1.0.3705"
+      case TargetRuntime.net_1_1 => "v1.1.4322"
+      case TargetRuntime.net_2_0 => "v2.0.50727"
+      case _ => "v4.0.30319"
+}
+
+object TargetRuntime {
+  def parseRuntime(self: String) =
+    if (self == null || self.length() == 0)
+      TargetRuntime.net_4_0
+    self.charAt(1) match
+      case '1' =>
+        if self.charAt(3) == '0' then TargetRuntime.net_1_0 else TargetRuntime.net_1_1
+      case '2' => TargetRuntime.net_2_0
+      case _ => TargetRuntime.net_4_0
+    
 }

--- a/src/cilantro/src/main/scala/cilantro/TypeDefinition.scala
+++ b/src/cilantro/src/main/scala/cilantro/TypeDefinition.scala
@@ -18,6 +18,8 @@ import io.spicelabs.cilantro.cil.CustomDebugInformation
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import io.spicelabs.cilantro.metadata.Row2
+import io.spicelabs.cilantro.AnyExtension.as
+import java.rmi.server.Operation
 
 
 
@@ -248,19 +250,159 @@ class TypeDefinition(namespace: String, name: String, private var _attributes: I
     def isNotPublic_=(value: Boolean) =
         _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.notPublic.value, value)
 
-    // TODO
+    def isPublic =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.public.value)
+    def isPublic_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.public.value, value)
 
+    def isNestedPublic =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPublic.value)
+    def isNestedPublic_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPublic.value, value)
+
+    def isNestedPrivate =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPrivate.value)
+    def isNestedPrivate_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedPrivate.value, value)
+
+    def isNestedFamily =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamily.value)
+    def isNestedFamily_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamily.value, value)
+
+    def isNestedAssembly =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedAssembly.value)
+    def isNestedAssembly_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedAssembly.value, value)
+
+    def isNestedFamilyAndAssembly =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamANDAssem.value)
+    def isNestedFamilyAndAssembly_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamANDAssem.value, value)
+
+    def isNestedFamilyOrAssembly =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamORAssem.value)
+    def isNestedFamilyOrAssembly_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.visibilityMask.value, TypeAttributes.nestedFamORAssem.value, value)
+
+    def isAutoLayout =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.autoLayout.value)
+    def isAutoLayout_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.autoLayout.value, value)
+
+    def isSequentialLayout =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.sequentialLayout.value)
+    def isSequentialLayout_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.sequentialLayout.value, value)
+
+    def isExplicitLayout =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.explicitLayout.value)
+    def isExplicitLayout_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.layoutMask.value, TypeAttributes.explicitLayout.value, value)
+
+    def isClass =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.`class`.value)
+    def isClass_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.`class`.value, value)
+
+    def isInterface =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.interface.value)
+    def isInterface_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.classSemanticMask.value, TypeAttributes.interface.value, value)
+
+    def isAbstract =
+        MemberDefinition.getAttributes(attributes, TypeAttributes.`abstract`.value)
+    def isAbstract_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(attributes, TypeAttributes.`abstract`.value, value)
+
+    def isSealed =
+        MemberDefinition.getAttributes(attributes, TypeAttributes.`sealed`.value)
+    def isSealed_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(attributes, TypeAttributes.`sealed`.value, value)
 
     def isSpecialName =
         MemberDefinition.getAttributes(_attributes, TypeAttributes.specialName.value)
     def isSpecialName_=(value: Boolean) =
         _attributes = MemberDefinition.setAttributes(_attributes, TypeAttributes.specialName.value, value)
 
+    def isImport =
+        MemberDefinition.getAttributes(attributes, TypeAttributes.`import`.value)
+    def isImport_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(attributes, TypeAttributes.`import`.value, value)
+
+    def isSerializable =
+        MemberDefinition.getAttributes(attributes, TypeAttributes.serializable.value)
+    def isSerializable_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(attributes, TypeAttributes.serializable.value, value)
+
+    def isWindowsRuntime =
+        MemberDefinition.getAttributes(attributes, TypeAttributes.windowsRuntime.value)
+    def isWindowsRuntime_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(attributes, TypeAttributes.windowsRuntime.value, value)
+
+    def isAnsiClass =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.ansiClass.value)
+    def isAnsiClass_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.ansiClass.value, value)
+
+    def isUnicodeClass =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.unicodeClass.value)
+    def isUnicodeClass_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.unicodeClass.value, value)
+
+    def isAutoClass =
+        MemberDefinition.getMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.autoClass.value)
+    def isAutoClass_=(value: Boolean) =
+        _attributes = MemberDefinition.setMaskedAttributes(_attributes, TypeAttributes.stringFormatMask.value, TypeAttributes.autoClass.value, value)
+
+    def isBeforeFieldInit =
+        MemberDefinition.getAttributes(_attributes, TypeAttributes.beforeFieldInit.value)
+    def isBeforeFieldInit_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(_attributes, TypeAttributes.beforeFieldInit.value, value)
+
     def isRuntimeSpecialName =
         MemberDefinition.getAttributes(_attributes, TypeAttributes.rtSpecialName.value)
     def isRuntimeSpecialName_=(value: Boolean) =
         _attributes = MemberDefinition.setAttributes(_attributes, TypeAttributes.rtSpecialName.value, value)
+
+    def hasSecurity =
+        MemberDefinition.getAttributes(_attributes, TypeAttributes.hasSecurity.value)
+    def hasSecurity_=(value: Boolean) =
+        _attributes = MemberDefinition.setAttributes(_attributes, TypeAttributes.hasSecurity.value, value)
+
+    def isEnum = base_type != null && base_type.isTypeOf("System", "Enum")
+
+    override def isValueType: Boolean =
+        if (base_type == null)
+            return false
+        base_type.isTypeOf("System", "Enum") || (base_type.isTypeOf("System", "ValueType") && !this.isTypeOf("System", "Enum"))
+    override def isValueType_=(value: Boolean): Unit = throw OperationNotSupportedException()
+
+    override def isPrimitive: Boolean =
+        MetadataSystem.tryGetPrimitiveElementType(this) match
+            case Some(primitive_etype) => primitive_etype.isPrimitive
+            case None => false
+        
+    override def metadataType: MetadataType =
+        MetadataSystem.tryGetPrimitiveElementType(this) match
+            case Some(primitive_type) => primitive_type.asMetadataType
+            case None => super.metadataType
+    
+    def getEnumUnderlyingType() =
+        var fields = _fields
+        fields.find((f) => f.isStatic) match
+            case Some(field) => field.fieldType
+            case None => throw IllegalArgumentException()
+        
+    def getNestedType(fullname: String) =
+        if (!hasNestedTypes)
+            null
+        else
+            nestedTypes.find((nt) => nt.typeFullName() == fullname) match
+                case Some(nt) => nt
+                case None => null
 }
+
 
 sealed class InterfaceImplementation(theInterfaceType: TypeReference, token: MetadataToken) extends CustomAttributeProvider {
     var _type: TypeDefinition = null

--- a/src/cilantro/src/main/scala/cilantro/TypeParser.scala
+++ b/src/cilantro/src/main/scala/cilantro/TypeParser.scala
@@ -1,0 +1,397 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/TypeParser.cs
+
+package io.spicelabs.cilantro
+
+import io.spicelabs.cilantro.TypeParser.tryGetArity
+import scala.util.boundary, boundary.break
+import io.spicelabs.cilantro.TypeParser.addInt
+import io.spicelabs.cilantro.TypeParser.addType
+import io.spicelabs.cilantro.TypeParser.addStr
+import io.spicelabs.cilantro.metadata.ElementType
+
+
+class TypeParser(private val _fullname: String) {
+    val _length = _fullname.length()
+    var _position = 0
+
+    private class Type {
+        var type_fullname: String = null
+        var nested_names: Array[String] = null
+        var arity = 0
+        var specs: Array[Int] = null
+        var generic_arguments: Array[TypeParser#Type] = null
+        var assembly: String = null
+    }
+
+    private def parseType(fq_name: Boolean) =
+        var `type` = Type()
+        `type`.type_fullname = parsePart()
+        `type`.nested_names = parseNestedNames()
+        if (tryGetArity(`type`))
+            `type`.generic_arguments = parseGenericArguments(`type`.arity)
+        
+        `type`.specs = parseSpecs()
+
+        if (fq_name)
+            `type`.assembly = parseAssemblyName()
+        
+        `type`
+    
+    private def parsePart() =
+        var part = StringBuilder()
+        while _position < _length do
+            if (_fullname.charAt(_position) == '\\')
+                _position += 1
+            part.append(_fullname.charAt(_position))
+            _position += 1
+        part.toString()
+    
+    private def tryParseWhiteSpace() =
+        while _position < _length && Character.isWhitespace(_fullname(_position)) do
+            _position += 1
+    
+    private def parseNestedNames() =
+        var nested_names: Array[String] = null
+        while tryParse('+') do
+            nested_names = addStr(nested_names, parsePart())
+        nested_names
+
+    private def tryParse(chr: Char) =
+        if (_position < _length && _fullname.charAt(_position) == chr)
+            _position += 1
+            true
+        else
+            false
+
+    private def parseSpecs(): Array[Int] =
+        var specs: Array[Int] = Array.emptyIntArray
+        boundary:
+            while _position < _length do
+                specs = _fullname.charAt(_position) match
+                    case '*' =>
+                        _position += 1
+                        addInt(specs, TypeParser.ptr)
+                    case '&' =>
+                        _position += 1
+                        addInt(specs, TypeParser.byRef)
+                    case '[' =>
+                        _position += 1
+                        _fullname.charAt(_position) match
+                            case ']' =>
+                                _position += 1
+                                addInt(specs, TypeParser.szArray)
+                            case '*' =>
+                                _position += 1
+                                addInt(specs, 1)
+                            case _ => 
+                                var rank = 1
+                                while tryParse(',') do
+                                    rank += 1
+                                specs = addInt(specs, rank)
+                                tryParse(']')
+                                specs
+                    case _ => break()
+        specs
+
+    private def parseGenericArguments(arity: Int): Array[TypeParser#Type] =
+        var generic_arguments: Array[TypeParser#Type] = Array[TypeParser#Type]()
+
+        if (_position == _length || _fullname.charAt(_position) != '[')
+            null
+        else
+            tryParse('[')
+
+            for i <- 0 until arity do
+                val fq_argument = tryParse('[')
+                generic_arguments = addType(generic_arguments, parseType(fq_argument))
+                if (fq_argument)
+                    tryParse(']')
+                tryParse(',')
+                tryParseWhiteSpace()
+            
+            tryParse(']')
+
+            generic_arguments
+
+    private def parseAssemblyName() =
+        if (!tryParse(','))
+            ""
+        else
+            tryParseWhiteSpace()
+            val start = _position
+            boundary:
+                while _position < _length do
+                    val chr = _fullname.charAt(_position)
+                    if (chr == '[' || chr == ']')
+                        break()
+                    _position += 1
+            _fullname.substring(start, _position - start)
+
+
+            
+}
+
+object TypeParser {
+    private def tryGetArity(`type`: TypeParser#Type): Boolean =
+        var arity = 0
+
+        arity = tryAddArity(`type`.type_fullname, arity)
+
+        val nested_names = `type`.nested_names
+        if (nested_names != null && nested_names.length > 0)
+            for i <- 0 until nested_names.length do
+                arity = tryAddArity(nested_names(i), arity)
+        `type`.arity = arity
+        arity > 0
+    
+    private def tryGetArity(name: String): Option[Int] =
+        val index = name.lastIndexOf('`')
+        if (index == -1)
+            None
+        else
+            parseInt32(name.substring(index + 1))
+    
+    private def parseInt32(value: String): Option[Int] = value.toIntOption
+
+    private def tryAddArity(name: String, arity: Int) =
+        tryGetArity(name) match
+            case Some(type_arity) => arity + type_arity
+            case None => arity
+    
+    private def isDelimeter(chr: Char) =
+        "+,[]*&".indexOf(chr) >= 0
+    
+    private def addInt(array: Array[Int], item: Int) =
+        if array == null then Array(item) else array :+ item
+    
+    private def addType(array: Array[TypeParser#Type], item: TypeParser#Type) =
+        if array == null then Array(item) else array :+ item
+    
+    private def addStr(array: Array[String], item: String) =
+        if array == null then Array(item) else array :+ item
+    
+    def parseType(module: ModuleDefinition, fullname: String, typeDefinitionOnly: Boolean = false) =
+        if (fullname == null || fullname.length() == 0)
+            null
+        else
+            val parser = TypeParser(fullname)
+            getTypeReference(module, parser.parseType(true), typeDefinitionOnly)
+
+    private def getTypeReference(module: ModuleDefinition, type_info: TypeParser#Type, type_def_only: Boolean): TypeReference =
+        val `type` = tryGetDefinition(module, type_info) match
+            case Some(atype) =>
+                createSpecs(atype, type_info)
+            case None =>
+                if (type_def_only)
+                    null
+                else
+                    createReference(type_info, module, getMetadataScope(module, type_info))
+        if `type` == null then null else createSpecs(`type`, type_info)
+
+    private def createSpecs(`type`: TypeReference, type_info: TypeParser#Type): TypeReference =
+        var thetype = tryCreateGenericInstanceType(`type`, type_info)
+        var specs = type_info.specs
+        if (specs == null || specs.length == 0)
+            thetype
+        else
+            for i <- 0 until specs.length do
+                thetype = specs(i) match
+                    case TypeParser.ptr => PointerType(thetype)
+                    case TypeParser.byRef => ByReferenceType(thetype)
+                    case TypeParser.szArray => ArrayType(thetype)
+                    case _ =>
+                        val array = ArrayType(thetype)
+                        array.dimensions.clear()
+                        for j <- 0 until specs(i) do
+                            array.dimensions.addOne((ArrayDimension(null, null)))
+                        array
+            thetype
+    
+    private def tryCreateGenericInstanceType(`type`: TypeReference, type_info: TypeParser#Type) =
+        val generic_arguments = type_info.generic_arguments
+        if (generic_arguments == null || generic_arguments.length == 0)
+            `type`
+        else
+            val instance = GenericInstanceType(`type`, generic_arguments.length)
+            val instance_arguments = instance.genericArguments
+
+            for i <- 0 until generic_arguments.length do
+                instance_arguments.addOne(getTypeReference(`type`.module, generic_arguments(i), false))
+            instance
+
+    def splitFullName(fullname: String): (String, String) =
+        var last_dot = fullname.lastIndexOf('.')
+        if (last_dot == -1)
+            ("", fullname)
+        else
+            (fullname.substring(0, last_dot), fullname.substring(last_dot + 1))
+
+    private def createReference(type_info: TypeParser#Type, module: ModuleDefinition, scope: MetadataScope): TypeReference =
+        val (namespace, name) = splitFullName(type_info.type_fullname)
+        var `type` = TypeReference(namespace, name, module, scope)
+        MetadataSystem.tryProcessPrimitiveTypeReference(`type`)
+
+        adjustGenericParameters(`type`)
+
+        val nested_names = type_info.nested_names
+        if (nested_names == null || nested_names.length == 0)
+            `type`
+        else
+            for i <- 0 until nested_names.length do
+                val nested = TypeReference("", nested_names(i), module, null)
+                nested.declaringType = `type`
+                `type` = nested
+                adjustGenericParameters(`type`)
+            `type`
+
+    private def adjustGenericParameters(`type`: TypeReference) =
+        tryGetArity(`type`.name) match
+            case Some(arity) =>
+                for i <- 0 until arity do
+                    `type`.genericParameters.addOne(GenericParameter(`type`))
+            case None => ()
+    
+    private def getMetadataScope(module: ModuleDefinition, type_info: TypeParser#Type): MetadataScope =
+        if (type_info.assembly == null || type_info.assembly.length() == 0)
+            module.typeSystem.coreLibrary
+        else
+            val reference = AssemblyNameReference.parse(type_info.assembly)
+            module.tryGetAssemblyNameReference(reference) match
+                case Some(m) => m
+                case None => reference
+    
+    private def tryGetDefinition(module: ModuleDefinition, type_info: TypeParser#Type): Option[TypeReference] =
+        var `type`: TypeReference = null
+        if (!tryCurrentModule(module, type_info))
+            return None
+        
+        var typedef = module.getType(type_info.type_fullname)
+        if (typedef == null)
+            return None
+        
+        val nested_names = type_info.nested_names
+        if (nested_names != null && nested_names.length > 0)
+            var failed = false
+            boundary:
+                for i <- 0 until nested_names.length do
+                    val nested_type = typedef.getNestedType(nested_names(i))
+                    if (nested_type == null)
+                        failed = true
+                        break()
+                    typedef = nested_type
+            if (failed)
+                return None
+        return Some(typedef)
+
+    private def tryCurrentModule(module: ModuleDefinition, type_info: TypeParser#Type): Boolean =
+        if (type_info.assembly == null || type_info.assembly.length() == 0)
+            return true
+        
+        if (module.assembly != null && module.assembly.name.fullName == type_info.assembly)
+            return true
+        
+        return false
+    
+    def toParseable(`type`: TypeReference, top_level: Boolean = true): String =
+        if (`type` == null)
+            null
+        else
+            val name = StringBuilder()
+            appendType(`type`, name, true, top_level)
+            name.toString()
+    
+    private def appendNamePart(part: String, name: StringBuilder) =
+        for c <- part do
+            if (isDelimeter(c))
+                name.append('\\')
+            name.append(c)
+    
+    private def appendType(`type`: TypeReference, name: StringBuilder, fq_name: Boolean, top_level: Boolean): Unit =
+        val element_type = `type`.getElementType()
+
+        val declaring_type = element_type.declaringType
+        if (declaring_type != null)
+            appendType(declaring_type, name, false, top_level)
+            name.append('+')
+        
+        val namespace = `type`.nameSpace
+        if (namespace != null && namespace.length() > 0)
+            appendNamePart(namespace, name)
+            name.append('.')
+        
+        appendNamePart(element_type.name, name)
+
+        if (fq_name)
+            if (`type`.isTypeSpecification())
+                appendTypeSpecification(`type`.asInstanceOf[TypeSpecification], name)
+            if (requiresFullyQualifiedName(`type`, top_level))
+                name.append(", ")
+                name.append(getScopeFullName(`type`))
+    
+    private def getScopeFullName(`type`: TypeReference) =
+        val scope = `type`.scope
+        scope.metadataScopeType match
+            case MetadataScopeType.assemblyNameReference => scope.asInstanceOf[AssemblyNameReference].fullName
+            case MetadataScopeType.moduleDefinition => scope.asInstanceOf[ModuleDefinition].assembly.name.fullName
+            case _ => throw IllegalArgumentException()
+    
+        
+    private def appendTypeSpecification(`type`: TypeSpecification, name: StringBuilder): Unit =
+        if (`type`.elementType.isTypeSpecification())
+            appendTypeSpecification(`type`.elementType.asInstanceOf[TypeSpecification], name)
+        
+        `type`.etype match
+            case ElementType.ptr => name.append('*')
+            case ElementType.byRef => name.append('&')
+            case ElementType.szArray | ElementType.array =>
+                val array = `type`.asInstanceOf[ArrayType]
+                if (array.isVector)
+                    name.append("[]")
+                else
+                    name.append("[")
+                    for i <- 1 until array.rank do name.append(',')
+                    name.append(']')
+            case ElementType.genericInst =>
+                val instance = `type`.asInstanceOf[GenericInstanceType]
+                val arguments = instance.genericArguments
+                name.append('[')
+
+                for i <- 0 until arguments.length do
+                    if (i > 0)
+                        name.append(',')
+                    val argument = arguments(i)
+                    val requires_fqname = argument.scope != argument.module
+
+                    if (requires_fqname)
+                        name.append('[')
+                    
+                    appendType(argument, name, true, false)
+
+                    if (requires_fqname)
+                        name.append(']')
+                name.append(']')
+            case _ => ()
+
+    private def requiresFullyQualifiedName(`type`: TypeReference, top_level: Boolean) =
+        if (`type`.scope == `type`.module ||
+            (`type`.scope.name == "mscorlib" && top_level))
+            false
+        else
+            true        
+
+
+    val ptr = -1
+    val byRef = -2
+    val szArray = -3
+
+}

--- a/src/cilantro/src/main/scala/cilantro/TypeReference.scala
+++ b/src/cilantro/src/main/scala/cilantro/TypeReference.scala
@@ -15,6 +15,7 @@ package io.spicelabs.cilantro
 import io.spicelabs.cilantro.metadata.ElementType
 import scala.collection.mutable.ArrayBuffer
 import javax.naming.OperationNotSupportedException
+import io.spicelabs.cilantro.AnyExtension.as
 
 
 enum MetadataType(val value: Byte) {
@@ -90,12 +91,14 @@ class TypeReference(private var _namespace: String, _name: String) extends Membe
     def isValueType_=(value: Boolean) = value_type = value
 
     override def module =
-        if (module != null) module
-
-        val declaring_type = declaringType
-        if (declaring_type != null)
-            declaring_type.module
-        null
+        if (_module != null)
+            _module
+        else
+            val declaring_type = declaringType
+            if (declaring_type != null)
+                declaring_type.module
+            else
+                null
 
     def windowsRuntimeProjection = projection.asInstanceOf[TypeReferenceProjection]
     def windowsRuntimeProjection_=(value: TypeReferenceProjection) = projection = value
@@ -216,7 +219,15 @@ class TypeReference(private var _namespace: String, _name: String) extends Membe
                 ElementType.sentinel |
                 ElementType.`var` => true
             case _ => false
-        
+    
+    def knownValueType() =
+        if (!isDefinition)
+            isValueType = true
 
+    def checkedResolve() =
+        var `type` = this.resolve()
+        if (`type` == null)
+            throw new OperationNotSupportedException(s"unable to resolve $this")
+        `type`.as[TypeDefinition]
 }
 

--- a/src/cilantro/src/main/scala/cilantro/TypeSystem.scala
+++ b/src/cilantro/src/main/scala/cilantro/TypeSystem.scala
@@ -1,0 +1,211 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/TypeSystem.cs
+
+package io.spicelabs.cilantro
+
+import io.spicelabs.cilantro.metadata.ElementType
+import io.spicelabs.cilantro.AnyExtension.as
+import javax.naming.OperationNotSupportedException
+import io.spicelabs.cilantro.metadata.Row2
+import scala.util.boundary,boundary.break
+
+abstract class TypeSystem(val _module: ModuleDefinition) {
+
+    var type_object: TypeReference = null
+    var type_void: TypeReference = null
+    var type_bool: TypeReference = null
+    var type_char: TypeReference = null
+    var type_sbyte: TypeReference = null
+    var type_byte: TypeReference = null
+    var type_int16: TypeReference = null
+    var type_uint16: TypeReference = null
+    var type_int32: TypeReference = null
+    var type_uint32: TypeReference = null
+    var type_int64: TypeReference = null
+    var type_uint64: TypeReference = null
+    var type_single: TypeReference = null
+    var type_double: TypeReference = null
+    var type_intptr: TypeReference = null
+    var type_uintptr: TypeReference = null
+    var type_string: TypeReference = null
+    var type_typedref: TypeReference = null
+
+    def lookupType(namespace: String, name: String): TypeReference
+
+    private def lookupSystemType(reference: TypeReference, name: String, element_type: ElementType, assigner: (TypeReference)=>Unit): TypeReference =
+        _module.syncRoot.synchronized {
+            if (reference != null)
+                reference
+            else
+                val `type` = lookupType("System", name)
+                `type`.etype = element_type
+                assigner(`type`)
+                `type`
+        }
+    
+    private def lookupSystemValueType(typeRef: TypeReference, name: String, element_type: ElementType, assigner: (TypeReference)=>Unit) =
+        _module.syncRoot.synchronized {
+            if (typeRef != null)
+                typeRef
+            else
+                val `type` = lookupType("System", name)
+                `type`.etype = element_type
+                `type`.knownValueType()
+                assigner(`type`)
+                `type`
+        }
+    
+    def coreLibrary =
+        val common = this.as[CommonTypeSystem]
+        if (common == null)
+            _module
+        else
+            common.getCoreLibraryReference()
+    
+    def `object` =
+        lookupSystemType(type_object, "Object", ElementType.`object`, (t)=>type_object = t)
+
+    def void =
+        lookupSystemType(type_void, "Void", ElementType.`object`, (t)=>type_void = t)
+    
+    def boolean =
+        lookupSystemValueType(type_bool, "Boolean", ElementType.boolean, (t)=>type_bool = t)
+    
+    def char =
+        lookupSystemValueType(type_char, "Char", ElementType.char, (t)=>type_char = t)
+    
+    def sByte =
+        lookupSystemValueType(type_sbyte, "SByte", ElementType.i1, (t)=>type_sbyte = t)
+    
+    def byte =
+        lookupSystemValueType(type_byte, "Byte", ElementType.u1, (t)=>type_byte = t)
+    
+    def int16 =
+        lookupSystemValueType(type_int16, "Int16", ElementType.i2, (t)=>type_int16 = t)
+    
+    def uInt16 =
+        lookupSystemValueType(type_uint16, "UInt16", ElementType.u2, (t)=>type_uint16 = t)
+    
+    def int32 =
+        lookupSystemValueType(type_int32, "Int32", ElementType.i4, (t)=>type_int32 = t)
+    
+    def uInt32 =
+        lookupSystemValueType(type_uint32, "UInt32", ElementType.u4, (t)=>type_uint32 = t)
+    
+    def int64 =
+        lookupSystemValueType(type_int64, "Int64", ElementType.i8, (t)=>type_int64 = t)
+    
+    def uInt64 =
+        lookupSystemValueType(type_uint64, "UInt64", ElementType.u8, (t)=>type_uint64 = t)
+
+    def single =
+        lookupSystemValueType(type_single, "Single", ElementType.r4, (t)=>type_single = t)
+    
+    def double =
+        lookupSystemValueType(type_double, "Double", ElementType.r8, (t)=>type_double = t)
+    
+    def intPtr =
+        lookupSystemValueType(type_intptr, "IntPtr", ElementType.i, (t)=>type_intptr = t)
+    
+    def uintPtr =
+        lookupSystemValueType(type_uintptr, "UIntPtr", ElementType.u, (t)=>type_uintptr = t)
+    
+    def string =
+        lookupSystemType(type_string, "String", ElementType.string, (t)=>type_string = t)
+    
+    def typedReference =
+        lookupSystemValueType(type_typedref, "TypedReference", ElementType.typedByRef, (t)=>type_typedref = t)
+}
+
+private sealed class CoreTypeSystem(__module: ModuleDefinition) extends TypeSystem(__module) {
+
+    override def lookupType(namespace: String, name: String): TypeReference =
+        val defn = lookupTypeDefinition(namespace, name)
+        var `type` = if defn != null then defn else lookupTypeForwarded(namespace, name)
+        if (`type` != null)
+            `type`
+        else
+            throw OperationNotSupportedException()
+        
+    def lookupTypeDefinition(namespace: String, name: String): TypeReference =
+        val metadata = _module.metadataSystem
+        if (metadata._types == null)
+            initialize(_module.types)
+        _module.read(Row2[String, String](namespace, name), (row, reader) => {
+                val types = reader.metadata._types
+
+                var result: TypeReference = null
+                boundary:
+                    for i <- 0 until types.length do
+                        if (types(i) == null)
+                            types(i) = reader.getTypeDefinition(i + 1)
+                        val `type` = types(i)
+
+                        if (`type`.name == row.col2 && `type`.nameSpace == row.col1)
+                            result = `type`
+                            break()
+                `result`
+                })
+    
+    def lookupTypeForwarded(namespace: String, name: String): TypeReference =
+        if (!_module.hasExportedTypes)
+            null
+        else
+            val exported_types = _module.exportedTypes
+            exported_types.find((ty) => ty.name == name && ty.nameSpace == namespace) match
+                case Some(exportedType) => exportedType.createReference()
+                case None => null
+    
+    def initialize(value: Any) = { }
+}
+
+private sealed class CommonTypeSystem(__module: ModuleDefinition) extends TypeSystem(__module) {
+    private var core_library: AssemblyNameReference = null
+
+    override def lookupType(namespace: String, name: String): TypeReference =
+        createTypeReference(namespace, name)
+    
+    def getCoreLibraryReference() =
+        if (core_library != null)
+            core_library
+        else _module.tryGetCoreLibraryReference() match
+            case Some(lib) =>
+                core_library = lib
+                core_library
+            case None =>
+                core_library = AssemblyNameReference()
+                core_library.name = ModuleDefinition.mscorlib
+                core_library.version = getCorelibVersion()
+                core_library.publicKeyToken = Array[Byte](0xb7.toByte, 0x7a, 0x5c, 0x56, 0x19, 0x34, 0xe0.toByte, 0x89.toByte)
+                _module.assemblyReferences.addOne(core_library)
+                core_library
+    def getCorelibVersion() =
+        _module.runtime match
+            case TargetRuntime.net_1_0 | TargetRuntime.net_1_1 => CSVersion(1, 0, 0, 0)
+            case TargetRuntime.net_2_0 => CSVersion(2, 0, 0, 0)
+            case TargetRuntime.net_4_0 => CSVersion(4, 0, 0, 0)
+            case null => throw OperationNotSupportedException()
+    
+    def createTypeReference(namespace: String, name: String) =
+        TypeReference(namespace, name, _module, getCoreLibraryReference())
+                    
+
+
+}
+
+object TypeSystem {
+    def createTypeSystem(module: ModuleDefinition) =
+        if (module.isCoreLibrary())
+            CoreTypeSystem(module)
+        else
+            CommonTypeSystem(module)
+}

--- a/src/cilantro/src/main/scala/cilantro/VariantType.scala
+++ b/src/cilantro/src/main/scala/cilantro/VariantType.scala
@@ -1,0 +1,47 @@
+//
+// Author:
+//   Jb Evain (jbevain@gmail.com) and Steve Hawley (sdh@spicelabs.io)
+//
+// Copyright (c) 2008 - 2015 Jb Evain
+// Copyright (c) 2008 - 2011 Novell, Inc.
+// Copyright (c) 2025 Spice Labs, Inc.
+//
+// Licensed under the MIT/X11 license.
+
+// Derived from https://github.com/jbevain/cecil/blob/3136847ea620fb9b4a3ff96bc4f573148e8bd2e4/Mono.Cecil/VariantType.cs
+
+package io.spicelabs.cilantro
+
+enum VariantType(val value: Int) {
+  case none extends VariantType(0)
+  case i2 extends VariantType(2)
+  case i4 extends VariantType(3)
+  case r4 extends VariantType(4)
+  case r8 extends VariantType(5)
+  case cy extends VariantType(6)
+  case date extends VariantType(7)
+  case bStr extends VariantType(8)
+  case dispatch extends VariantType(9)
+  case error extends VariantType(10)
+  case bool extends VariantType(11)
+  case variant extends VariantType(12)
+  case unknown extends VariantType(13)
+  case decimal extends VariantType(14)
+  case i1 extends VariantType(16)
+  case ui1 extends VariantType(17)
+  case ui2 extends VariantType(18)
+  case ui4 extends VariantType(19)
+  case i8 extends VariantType(20)
+  case ui8 extends VariantType(21)
+  case int extends VariantType(22)
+  case uint extends VariantType(23)
+}
+
+object VariantType {
+  def fromOrdinalValue(value: Int): VariantType =
+    VariantType.values.find(x => {x.value == value}) match
+      case Some(result) => result
+      case None => throw IllegalArgumentException(s"value $value not found in VariantType")
+  def fromOrdinalValue(value: Byte): VariantType =
+    fromOrdinalValue(value.toInt & 0xff)
+}

--- a/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
+++ b/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
@@ -3,6 +3,7 @@ import java.nio.*
 import java.nio.file.*
 import java.io.FileInputStream
 import io.spicelabs.cilantro.PE.BinaryStreamReader
+import io.spicelabs.cilantro.AnyExtension.as
 
 class SmokeTests extends munit.FunSuite {
     import SmokeTests.smokePath
@@ -60,6 +61,22 @@ class SmokeTests extends munit.FunSuite {
         assertEquals(asrefs.length, 1)
 
 
+    }
+
+    test ("check-assembly-info") {
+        val strPath = smokePathStr()
+        val assem = AssemblyDefinition.readAssembly(strPath)
+        assertEquals(assem.customAttributes.length, 10)
+        val attr = assem.customAttributes(4)
+        val hasCtorArgs = attr.hasConstructorArguments
+        assert(hasCtorArgs)
+        val args = attr.constructorArguments
+        assertEquals(args.length, 1)
+        val arg = args(0)
+        assertEquals(arg.`type`.fullName, "System.String")
+        val value = arg.value.as[String]
+        assertNotEquals(value, null)
+        assertEquals(value, "Smoke")
     }
 }
 


### PR DESCRIPTION
This PR makes CustomAttribute reading active.

Like most things in cecil, access to any particular element in an assembly is fully lazy, so these attributes don't get read until they're referenced. I had stubbed out all the code, but most of it was TODO, so I pulled on the thread for that and filled in the code that's necessary to read custom attributes.

In doing this, I found several classes of error on my part:
- assuming that `if` statements short circuit a return value (they don't, of course)
- incorrect handling of overrides in collection bottlenecks
- issues with referencing inner classes from `object` methods (you can't)

Tests pass, but there are still at least one problem that I need to sort out:
https://github.com/spice-labs-inc/cilantro/issues/12
