### PR TITLE
fixed missing odd attributes

### DIFF
--- a/src/cilantro/src/main/scala/cilantro.metadata/Utilities.scala
+++ b/src/cilantro/src/main/scala/cilantro.metadata/Utilities.scala
@@ -126,7 +126,7 @@ extension (self: CodedIndex)
                 case _ => MetadataToken.zero
         case CodedIndex.customAttributeType =>
             val rid = data >>> 3
-            data & 3 match
+            data & 7 match
                 case 2 => MetadataToken(TokenType.method, rid)
                 case 3 => MetadataToken(TokenType.memberRef, rid)
                 case _ => MetadataToken.zero

--- a/src/cilantro/src/main/scala/cilantro/CustomAttribute.scala
+++ b/src/cilantro/src/main/scala/cilantro/CustomAttribute.scala
@@ -56,7 +56,7 @@ sealed class CustomAttribute(var _signature: Int, private var _constructor: Meth
     def constructor = _constructor
     def constructor_(value: MethodReference) = _constructor = value
 
-    def attributeType = null // TODO constructor.declaringType
+    def attributeType = constructor.declaringType
 
     def isResolved = _resolved
 

--- a/src/cilantro/src/main/scala/cilantro/MetadataSystem.scala
+++ b/src/cilantro/src/main/scala/cilantro/MetadataSystem.scala
@@ -111,7 +111,7 @@ sealed class MetadataSystem {
             _typeReferences(rid - 1)
     
     def addTypeReference(`type`: TypeReference) =
-        _typeReferences(`type`.token.RID) = `type`
+        _typeReferences(`type`.token.RID - 1) = `type`
 
     def getFieldDefinition(rid: Int) = 
         if (rid < 1 || rid > _fields.length)
@@ -120,7 +120,7 @@ sealed class MetadataSystem {
             _fields(rid - 1)
 
     def addFieldDefinition(field: FieldDefinition) =
-        _fields(field.token.RID) = field
+        _fields(field.token.RID - 1) = field
 
 
     def getMethodDefinition(rid: Int) = 
@@ -130,7 +130,7 @@ sealed class MetadataSystem {
             _methods(rid - 1)
 
     def addMethodDefinition(method: MethodDefinition) =
-        _methods(method.token.RID) = method
+        _methods(method.token.RID - 1) = method
 
 
     def getMemberReference(rid: Int) =
@@ -140,7 +140,7 @@ sealed class MetadataSystem {
             _memberReferences(rid - 1)
     
     def addMemberReference(member: MemberReference) =
-        _memberReferences(member.token.RID) = member
+        _memberReferences(member.token.RID - 1) = member
 
     def tryGetNestedTypeMapping(`type`: TypeDefinition) =
         _nestedTypes.get(`type`.token.RID)

--- a/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
+++ b/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
@@ -78,6 +78,23 @@ class SmokeTests extends munit.FunSuite {
         assertNotEquals(value, null)
         assertEquals(value, "Smoke")
     }
+
+    test("complete-assembly-info") {
+        val strPath = smokePathStr()
+        val assem = AssemblyDefinition.readAssembly(strPath)
+        assertEquals(assem.customAttributes.length, 10)
+        val names = assem.customAttributes.map((attr) => attr.attributeType.name).toArray
+        val expected = Array("CompilationRelaxationsAttribute", "RuntimeCompatibilityAttribute",
+            "DebuggableAttribute", "TargetFrameworkAttribute",
+            "AssemblyCompanyAttribute", "AssemblyConfigurationAttribute",
+            "AssemblyFileVersionAttribute", "AssemblyInformationalVersionAttribute",
+            "AssemblyProductAttribute", "AssemblyTitleAttribute")
+        if (!names.sameElements(expected))
+            val differing = (names zip expected).indexWhere((x, y) => x != y)
+            val ex = expected(differing)
+            val act = names(differing)
+            assert(false, s"Lists differ at index $differing\nExpected $ex but got $act")
+    }
 }
 
 object SmokeTests {


### PR DESCRIPTION
This sorts out [this issue](https://github.com/spice-labs-inc/cilantro/issues/12).

What was going on was that the `get` method was looking in the right place but the `add` method was adding it one further. This meant that even entries read, but were being stored in the odd entries' cache location, so odd entries were being read from them.

found a TODO property getter and fixed that.

I did a search through the C# code base for everywhere a `RID - 1` existed, found several others and fixed those too.

In debugging, I noted an incorrect bit mask which was inconsequential for this test, but will matter at some point.