### PR TITLE
fixed an issue reading properties and fields

### DIFF
--- a/src/cilantro/src/main/scala/cilantro/AssemblyReader.scala
+++ b/src/cilantro/src/main/scala/cilantro/AssemblyReader.scala
@@ -1308,8 +1308,16 @@ sealed class MetadataReader(val image: Image, val module: ModuleDefinition, val 
             return ()
         
         val (fields, props) = reader.readCustomArgumentAttributeNamedArguments(named)
-        attribute.fields.addAll(fields)
-        attribute.properties.addAll(props)
+        if (fields != null)
+            if (attribute._fields == null)
+                attribute._fields = fields
+            else
+                attribute._fields.addAll(fields)
+        if (props != null)
+            if (attribute._properties == null)
+                attribute._properties = props
+            else
+                attribute._properties.addAll(props)
 
     private def initializeMarshalInfos() = { } // TODO
 

--- a/src/cilantro/src/main/scala/cilantro/CustomAttribute.scala
+++ b/src/cilantro/src/main/scala/cilantro/CustomAttribute.scala
@@ -50,8 +50,8 @@ trait CustomAttributeTrait {
 sealed class CustomAttribute(var _signature: Int, private var _constructor: MethodReference, var _blob:Array[Byte], private var _resolved: Boolean) extends CustomAttributeTrait {
     
     var _arguments: ArrayBuffer[CustomAttributeArgument] = null
-    private var _fields: ArrayBuffer[CustomAttributeNamedArgument] = null
-    private var _properties: ArrayBuffer[CustomAttributeNamedArgument] = null
+    var _fields: ArrayBuffer[CustomAttributeNamedArgument] = null
+    var _properties: ArrayBuffer[CustomAttributeNamedArgument] = null
 
     def constructor = _constructor
     def constructor_(value: MethodReference) = _constructor = value

--- a/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
+++ b/src/cilantro/src/test/scala/cilantro.metadata/SmokeTests.scala
@@ -95,6 +95,13 @@ class SmokeTests extends munit.FunSuite {
             val act = names(differing)
             assert(false, s"Lists differ at index $differing\nExpected $ex but got $act")
     }
+
+    test("has-properties") {
+        val strPath = smokePathStr()
+        val assem = AssemblyDefinition.readAssembly(strPath)
+        val allWithProps = assem.customAttributes.map((attr) => if attr.hasProperties then 1 else 0).sum
+        assertEquals(allWithProps , 2, "should have properties")
+    }
 }
 
 object SmokeTests {


### PR DESCRIPTION
This addresses [this issue](https://github.com/spice-labs-inc/cilantro/issues/12)

The problem stemmed from several causes. The first is that in C# the changes to the fields collections were being done via backing fields that were passed as `ref` parameters. Scala doesn't have the notion of `ref` parameters, so I implemented code that passed in the backing field collections and returned a tuple with the (possibly) modified collection, thinking I could do an `addAll` when it came up for air. This didn't work as it was for a couple of reasons:

- if there are no fields (and in this test there are none), the `fields` element of the tuple comes back null and doing an `addAll` causes a null reference exception.
- the accessors, `attribute.fields` and `attribute.properties` are code that first calls a method named `resolve()` that is a lazy read of the collections. `resolve()` goes through a maze of twisty little passages passing through a `try/catch` block before the `addAll` call. The call, `attribute.fields.addAll(fields)` hits the accessor `fields` which calls `resolve()` which no results in infinite recursion causing a stack overflow, which gets caught by the try catch and everything gets cleaned up without actually storing the read fields/properties.
- the backing fields are null at this point, which if you try to do an `addAll` causes a null reference exception.

There are a number of different ways to solve this. One is to pass in functors that can mutate the backing fields and call those in the read code. This is nice in that it maintains the privacy of the fields at the cost of the code being less straightforward and the code becomes much more divergent from the C#.

Another is to address the re-entrancy of the `resolve` by putting in a flag to short circuit if it's in the process of being resolved. This is a cleaner solution, but it is a big change to the semantics of `resolve` compared to the C#.

I chose to make the backing fields public, which is not ideal from an encapsulation standpoint, but is expedient and keeps the code closer in sync with the C# in terms of when mutation happens.

"Steve, why are you being a stickler for keeping the code paths parallel?" The reason being, and this is an important one, is that I can keep the debugging time way, way down by running the same test in C# and in Scala and tracing the code side by side. This has saved my bacon 3 or 4 times so far for finding subtle bugs as well as spotting typos.