### PR TITLE
Remove Redundant Artifact

### DIFF
--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -44,11 +44,6 @@ Global / excludeLintKeys += pgpPassphrase
 Compile / packageBin := (Compile /  packageBin).value
 
 publishMavenStyle := true
-publish / packagedArtifacts += (Artifact (
-  projectName,
-  "jar",
-  "jar"
-) -> (Compile / packageBin).value)
 
 lazy val root = project
   .in(file("."))


### PR DESCRIPTION
sbt publishes source, docs, and a jar by default. The extra declaration of an artifact was trying to upload a second jar, which won't work.