### PR TITLE
switch over to using sbt-publish-more

### DIFF
--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -25,11 +25,17 @@ ThisBuild / developers := List(
   )
 )
 
-// git publish
-ThisBuild / publishTo := {
-  val repo = "https://maven.pkg.github.com/spice-labs-inc/cilantro"
-  Some("GitHub Package Registry" at repo)
-}
+publishResolvers := Seq(
+  Resolver.url("GitHub Package Registry", url("https://maven.pkg.github.com/spice-labs-inc/cilantro"))
+)
+
+publish := publishAll.value
+
+// // git publish
+// ThisBuild / publishTo := {
+//   val repo = "https://maven.pkg.github.com/spice-labs-inc/cilantro"
+//   Some("GitHub Package Registry" at repo)
+// }
 
 credentials += Credentials(
   "GitHub Package Registry",

--- a/src/cilantro/project/plugins.sbt
+++ b/src/cilantro/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+addSbtPlugin("laughedelic" % "sbt-publish-more" % "0.1.0")


### PR DESCRIPTION
sbt doesn't like publishing to multiple repositories, so my cunning plan was to have two `build.sbt` files and invoke sbt on each.

sbt has an operational model where it specifically _prevents_ the ability to be pointed at a specific sbt files.

Apparently, we are not the first to tread these waters and there are a couple different ways that are used to handle this, including a great deal of conditional code within the build.sbt file or using the plug in [sbt-publish-more](https://github.com/laughedelic/sbt-publish-more).

The latter seems to be the cleanest way to do this.

Step 1: repurpose the existing built.sbt to publish using sbt-publish-more to ensure that it still works.