### PR TITLE
add in elements for maven publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,89 +54,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github
+          SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          PGP_SECRET: ${{ MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+         
 
-      
-
-  publish-to-central:
-    name: Re-publish cilantro to Maven Central
-    runs-on: ubuntu-24.04
-    needs: publish-jars
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-      
-      - name: Write settings.xml for Central
-        run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml <<EOF
-          <settings>
-            <servers>
-              <server>
-                <id>central</id>
-                <username>${{ secrets.MAVEN_CENTRAL_USERNAME }}</username>
-                <password>${{ secrets.MAVEN_CENTRAL_PASSWORD }}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
-
-      - name: Import GPG key
-        run: |
-          echo "${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}" | gpg --batch --import
-
-
-      - name: Set project version from tag
-        run: |
-          mvn -B --file maven/pom.xml \
-              clean versions:set -DnewVersion="${{ needs.publish-jars.outputs.version }}" -DgenerateBackupPoms=false
-
-      - name: Create target dir
-        run: mkdir -p maven/target/external
-
-      - name: Download artifacts from GitHub Maven
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.publish-jars.outputs.version }}
-        run: |
-          ARTIFACTS=(
-            "cilantro-${VERSION}.jar"
-            "cilantro-${VERSION}.pom"
-          )
-          for file in "${ARTIFACTS[@]}"; do
-            echo "Downloading $file"
-            curl -fL -o "maven/target/external/$file" \
-              -H "Authorization: Bearer $GITHUB_TOKEN" \
-              -H "Accept: application/octet-stream" \
-              "https://maven.pkg.github.com/spice-labs-inc/cilantro/io/spicelabs/cilantro/${VERSION}/${file}"
-          done
-
-      - name: Inject real dependencies block into fake pom.xml
-        run: |
-          set -e
-
-          VERSION="${{ needs.publish-jars.outputs.version }}"
-          REAL_POM="maven/target/external/cilantro-${VERSION}.pom"
-          FAKE_POM="maven/pom.xml"
-          real_deps=$(awk '/<dependencies>/,/<\/dependencies>/' "$REAL_POM")
-          awk -v repl="$real_deps" '
-            /<!-- @REAL_DEPENDENCIES@ -->/ {print repl; next}
-            {print}
-          ' "$FAKE_POM" > "${FAKE_POM}.tmp" && mv "${FAKE_POM}.tmp" "$FAKE_POM"
-
-
-      - name: Publish to Maven Central (staging only)
-        run: |
-          cd maven
-          mvn --batch-mode deploy
-        env:
-          GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}

--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -1,14 +1,19 @@
 val projectName = "cilantro"
 val scala3Version = "3.7.1"
 
-ThisBuild / organization := "io.spicelabs"
-ThisBuild / version := "0.0.1-SNAPSHOT" // overridden by GitHub Actions
 
+val _homepage = Some(url("https://github.com/spice-labs-inc/cilantro"))
+
+ThisBuild / organization := "io.spicelabs"
+ThisBuild / organizationName := "Spice Labs"
+ThisBuild / organizationHomepage := _homepage
+ThisBuild / version := "0.0.1-SNAPSHOT" // overridden by GitHub Actions
+ThisBuild / description := "A scala library for manipulating Microsoft .NET PE files"
 ThisBuild / licenses := Seq(
   "MIT License" -> url("https://mit-license.org/") 
 )
 
-ThisBuild / homepage := Some(url("https://github.com/spice-labs-inc/cilantro"))
+ThisBuild / homepage := _homepage
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/spice-labs-inc/cilantro"),
@@ -26,16 +31,11 @@ ThisBuild / developers := List(
 )
 
 publishResolvers := Seq(
-  Resolver.url("GitHub Package Registry", url("https://maven.pkg.github.com/spice-labs-inc/cilantro"))
+  Resolver.url("GitHub Package Registry", url("https://maven.pkg.github.com/spice-labs-inc/cilantro")),
+  localStaging.value
 )
 
 publish := publishAll.value
-
-// // git publish
-// ThisBuild / publishTo := {
-//   val repo = "https://maven.pkg.github.com/spice-labs-inc/cilantro"
-//   Some("GitHub Package Registry" at repo)
-// }
 
 credentials += Credentials(
   "GitHub Package Registry",

--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -32,7 +32,7 @@ ThisBuild / developers := List(
 
 publishResolvers := Seq(
   Resolver.url("GitHub Package Registry", url("https://maven.pkg.github.com/spice-labs-inc/cilantro")),
-  localStaging.value
+  localStaging.value.get
 )
 
 publish := publishAll.value


### PR DESCRIPTION
What's here -
I followed the guide [here](https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html) and made sure that the environment contains the elements that sbt wants and set up the multipublishing in the `build.sbt` file. After talking with Dani, decided to not include staging.

But - this seems too easy? There's no doubt a lot going on under the covers to enable this.

I do have questions though - the aforementioned guide uses `localStaging.value` which I couldn't find a lot of information about. I also did a search through github to find usage of it and it seems to be only used by projects that have copied this guide.

The guide also mentions using publishSigned, sonaUpload, and sonaRelease. I don't know if these will get invoked by doing `sbt publish` or if there's more that we need to do.

Feedback welcome.