### PR TITLE
chore: sync CONTRIBUTING.md from org community-files repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,6 @@ Follow the coding style used in the project:
    git commit -m "Handle timeouts in API client with retries with backoff"
    git push origin fix/handle-timeouts
    ```
-
 - Longer commit messages are welcome, describing the approach, alternatives considered, or useful explanations of the change.
 - Please make your commits as focused as possible. It is better to have two smaller commits for unrelated changes than a combined commit with a vague title such as "updates" or "changes."
 


### PR DESCRIPTION
This PR syncs **CONTRIBUTING.md** from [`spice-labs-inc/community-files`](https://github.com/spice-labs-inc/community-files).
Source file: `CONTRIBUTING.md`
Created by: `.github/workflows/sync-contributing.yml`