### PR TITLE
call sonaPublish from the workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Publish standard and fat JARs to GitHub Packages
         run: 
-          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" +publish
+          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" "+publish ; sonaRelease"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github

--- a/src/cilantro/build.sbt
+++ b/src/cilantro/build.sbt
@@ -1,3 +1,5 @@
+import sbt.internal.librarymanagement
+
 val projectName = "cilantro"
 val scala3Version = "3.7.1"
 


### PR DESCRIPTION
It looks like the way to get sbt to actually do the publishing to maven central is to make the sbt invocation include a compound command.