### PR TITLE
actually sign the artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           echo "${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}" | gpg --batch --import
       - name: Publish standard and fat JARs to GitHub Packages
         run: 
-          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" "+publish ; sonaRelease"
+          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" "+publishSigned ; sonaRelease"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github


### PR DESCRIPTION
It looks like signing doesn't happen unless you do publishSigned.
Hopefully publishSigned will first call publish then do the signing.