### PR TITLE
split into two publishing steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,15 +51,29 @@ jobs:
       - name: Import PGP Key
         run: |
           echo "${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}" | gpg --batch --import
-      - name: Publish standard and fat JARs to GitHub Packages
-        run: 
-          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" "+publishSigned ; sonaRelease"
+
+      - name: Publish JARs to GitHub Packages
+        run:
+          # src/cilantro has the build.sbt files, hence the cd to get there
+          cd src/cilantro && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" +publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TARGET: github
+          PGP_SECRET: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
+          PGP_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+
+       - name: Publish signed Jars to Maven Central
+         # src/cilantro has the build.sbt files
+         # rename build.sbt to build.sbt.ghc
+         # rename build.sbt.maven to build.sbt
+         # run a compound command:
+         #    publishSigned should build the project to local staging and sign it
+         #    soneRelease should upload to to maven central and auto-release it
+         run:
+           cd src/cilantro && mv build.sbt build.sbt.ghc && mv build.sbt.maven build.sbt && SBT_OPTS="-Xmx8G -Duser.timezone=GMT" sbt "set ThisBuild / version := \"${{ env.projectVersion }}\"" "+publishSigned ; sonaRelease"
+        env:
           SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           PGP_SECRET: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
           PGP_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
          
-

--- a/src/cilantro/build.sbt.maven
+++ b/src/cilantro/build.sbt.maven
@@ -37,19 +37,11 @@ ThisBuild / developers := List(
   )
 )
 
-// This will publish to github
+// This will publish to local staging, which can then be used to publish
+// to maven central
 ThisBuild / publishTo := {
-  val repo = "https://maven.pkg.github.com/spice-labs-inc/cilantro"
-  Some("GitHub Package Registry" at repo)
+    localStaging.value
 }
-
-// Credentials for publishing to github
-credentials += Credentials(
-  "GitHub Package Registry",
-  "maven.pkg.github.com",
-  "x-access-token",
-  sys.env.getOrElse("GITHUB_TOKEN", "")
-)
 
 // make the PGP_PASSPHRASE available
 ThisBuild / pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray)

--- a/src/cilantro/project/plugins.sbt
+++ b/src/cilantro/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
-addSbtPlugin("laughedelic" % "sbt-publish-more" % "0.1.0")


### PR DESCRIPTION
What's going on in this change:
It looks like the publish-more plug-in can't handle publishSigned. It does a double publish (don't ask me why) and that makes github get rightly upset.
Without publishSigned, maven central won't accept the artifacts (as it shouldn't)
As such, we can't use publish-more, so that plug-in has been removed.

In theory, we could sign it ourselves, but I'd rather we leave the signing process to the build since any changes due to process changes or security issues will be handled there. In other words, we're trying to avoid tech debt.

I'm opting to have one `build.sbt` file and one `build.sbt.maven` file. We publish with the first one and then save the original file and rename the maven file to `build.sbt` and do `publishSigned` and `sonaRelease`. This should get the signed artifacts to maven central.

Finally, I documented what the files do and opened an issue to investigate trying to unify the two sbt files [here](https://github.com/spice-labs-inc/cilantro/issues/44).