### PR TITLE
Add ADG scan to cilantro publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,4 +76,10 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           PGP_SECRET: ${{ secrets.MAVEN_CENTRAL_GPG_PRIVATE_KEY }}
           PGP_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
-         
+      
+      - name: Index and upload ADG
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          token: ${{ secrets.SPICE_PASS }}
+          input: src/cilantro/target
+          tag: ${{ github.event.repository.name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,5 +81,5 @@ jobs:
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
           spice_pass: "${{ secrets.SPICE_PASS }}"
-          file_path: "./target"
+          file_path: "${{ github.workspace }}"
           tag: "${{ github.event.repository.name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,6 @@ jobs:
       - name: Index and upload ADG
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
-          token: ${{ secrets.SPICE_PASS }}
-          input: src/cilantro/target
-          tag: ${{ github.event.repository.name }}
+          spice_pass: "${{ secrets.SPICE_PASS }}"
+          file_path: "./target"
+          tag: "${{ github.event.repository.name }}"


### PR DESCRIPTION
Adds a single step to index and upload ADGs using spice-labs-inc/action-spice-labs-cli-scan@v3.

Successful after: https://github.com/spice-labs-inc/cilantro/issues/48

**Testing**

1. Create a release (e.g., tag vX.Y.Z).
2. Confirm GitHub Packages + Maven Central publishing proceed as before.
3. Verify the new “Index and upload ADG” step runs and uploads ADGs to Spice Labs.
  - Link to successful run: https://github.com/spice-labs-inc/cilantro/actions/runs/17848237656
  - Screenshots of upload & dashboard
 
<img width="997" height="112" alt="image" src="https://github.com/user-attachments/assets/90fcbc72-3e4d-4328-b8b6-f08226b65f27" />
<img width="1008" height="100" alt="image" src="https://github.com/user-attachments/assets/a74936bd-0094-4c05-aaca-a1a929bf9e42" />

