### PR TITLE
Upgrade Actions and Runner for Node.js 24 Compatibility

### DIFF
--- a/.github/workflows/build-and-test-scala.yml
+++ b/.github/workflows/build-and-test-scala.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout with LFS
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 


### PR DESCRIPTION
### Summary

Updates both CI workflows to resolve Node.js 20 deprecation warnings on GitHub
Actions runners. `actions/checkout` has been updated to v5 in both
`build-and-test-scala.yml` and `publish.yml` ahead of the June 16th enforcement
date.

### Changes

- Updated `actions/checkout` from `@v4` to `@v5` in `build-and-test-scala.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in `publish.yml`

### Tests

- Push to any branch and confirm the `Scala CI` build job completes
  successfully, including JDK 21 setup and `sbt test` from the `src/cilantro`
  working directory
- Publish a release with a semver tag (e.g. `v1.2.3`) and confirm the
  `publish-jars` job completes successfully, including JAR publication to
  GitHub Packages and Maven Central, PGP signing, and ADG upload
- Verify the `cd src/cilantro` working directory is correctly applied in both
  sbt publish steps

### Impact

No change to build, test, or publish behaviour. All runners were already
correctly pinned to `ubuntu-24.04` and all other actions
(`actions/setup-java@v4`, `sbt/setup-sbt@v1`,
`spice-labs-inc/action-spice-labs-surveyor@v5`) required no changes.

### Ticket

- https://github.com/spice-labs-inc/internal-docs/issues/509