### PR TITLE
fix: use github.event.release.tag_name for release tag validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,10 +39,13 @@ jobs:
       - name: Derive and validate version
         id: version
         shell: bash
+        env:
+          # tag_name is "vX.Y.Z" (no refs/tags/ prefix) for the release event.
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          raw_version="${GITHUB_REF#refs/tags/v}"
+          raw_version="${TAG_NAME#v}"
           if [[ ! "$raw_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format: $raw_version. Must be v<major>.<minor>.<patch>." >&2
+            echo "Invalid tag format: $TAG_NAME. Must be v<major>.<minor>.<patch>." >&2
             exit 1
           fi
           echo "projectVersion=$raw_version" >> "$GITHUB_ENV"


### PR DESCRIPTION
actions/checkout v5+ no longer sets GITHUB_REF to refs/tags/<tag> when checking out via ref: github.event.release.tag_name. GITHUB_REF now resolves to the default branch ref, so the tag/semver regex fails. Read the tag from github.event.release.tag_name ("vX.Y.Z") directly via an env var, which shortens the regex and surfaces the actual value in the error message.
